### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.1...v0.1.2) - 2026-05-04
+
+### Other
+
+- ignore round-7 'A' QuadCurveTo assertion ([#6](https://github.com/OxideAV/oxideav-scribe/pull/6))
+- ignore round-4 double-diacritic y_offset assertion ([#5](https://github.com/OxideAV/oxideav-scribe/pull/5))
+- ignore round-3 sub-pixel bitmap tests pending horizontal AA ([#4](https://github.com/OxideAV/oxideav-scribe/pull/4))
+- silence rust 1.95 needless_range_loop + manual_range_contains
+- re-land round 5: CBDT/CBLC color bitmap glyphs
+
 ### Added — round 7, vector-first text export (2026-05-04)
 
 - `Face::glyph_path(glyph_id) -> Option<oxideav_core::Path>` — returns

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-scribe"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-scribe`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.1...v0.1.2) - 2026-05-04

### Other

- ignore round-7 'A' QuadCurveTo assertion ([#6](https://github.com/OxideAV/oxideav-scribe/pull/6))
- ignore round-4 double-diacritic y_offset assertion ([#5](https://github.com/OxideAV/oxideav-scribe/pull/5))
- ignore round-3 sub-pixel bitmap tests pending horizontal AA ([#4](https://github.com/OxideAV/oxideav-scribe/pull/4))
- silence rust 1.95 needless_range_loop + manual_range_contains
- re-land round 5: CBDT/CBLC color bitmap glyphs

### Added — round 7, vector-first text export (2026-05-04)

- `Face::glyph_path(glyph_id) -> Option<oxideav_core::Path>` — returns
  the raw glyph outline as vector commands in the font's native Y-up
  font-unit coordinate space. TT outlines map to `MoveTo` + `LineTo`
  + `QuadCurveTo` + `Close` (with the standard implicit-on-curve
  midpoint reconstruction for adjacent off-curve points). CFF outlines
  map to `MoveTo` + `LineTo` + `CubicCurveTo` + `Close`, mirroring the
  Type 2 charstring decode 1:1. Bitmap-only glyphs (CBDT-only fonts)
  return `None`.
- `Face::glyph_node(glyph_id, size_px) -> Option<oxideav_core::Node>`
  — returns a self-contained `Node` ready to be positioned at the pen
  origin. Outline glyphs come back as `Node::Path(PathNode)` with the
  Y-flip + size scale baked in (origin at (0, 0) = pen origin, Y grows
  downward), with a default black solid fill. Bitmap glyphs (CBDT,
  e.g. Noto Color Emoji) come back as `Node::Image(ImageRef)` carrying
  the rasterised RGBA bitmap as an `oxideav_core::VideoFrame`, with
  `bounds` sized to the bitmap's CBDT-declared placement at the
  strike's native ppem (scaled by `size_px / strike_ppem`). COLRv1
  layered glyphs fall through to the base outline path for now —
  round 6 (#356) extends `glyph_node` to return a `Group` of layered
  PathNodes per COLR layer.
- `Shaper::shape_to_paths(face_chain, text, size_px) -> Vec<(usize,
  Node, Transform2D)>` — primary vector text API. Shapes through the
  full GSUB / GPOS / mark-attachment / face-chain-fallback pipeline,
  then wraps each glyph in a `Node` and a positioning `Transform2D`
  (pure translation by the cumulative pen advance + per-glyph
  kerning / mark x_offset / y_offset). Non-rendering glyphs (SPACE,
  empty outlines) advance the pen but do not appear in the output
  vector — the returned length is `<= shaped.len()`.
- The existing rasterise APIs (`render_text`, `render_text_styled`,
  `render_text_wrapped`, `Composer::compose_run*`) are **unchanged**
  in this round — they keep returning `RgbaBitmap`. Removal /
  rewriting in terms of the vector pipeline is task #354.
- `oxideav-core` minimum bumped to `0.1.14` for the `vector` module
  types (`Path`, `PathCommand`, `Node`, `PathNode`, `ImageRef`,
  `Paint`, `FillRule`, `Transform2D`, `Rect`, `Rgba`, `Point`).
- New integration tests:
  - `tests/round7_glyph_path.rs` — DejaVu Sans Mono 'A' must emit
    `MoveTo` + `Close` + ≥1 `QuadCurveTo` and zero cubics; SPACE
    returns `None`.
  - `tests/round7_glyph_path_cff.rs` — Source Sans 3 'A' must emit
    `MoveTo` + `Close` + ≥1 `CubicCurveTo` and zero quads.
  - `tests/round7_shape_to_paths.rs` — DejaVu Sans Mono "Hi" must
    return 2 `PathNode`s with the second translated rightward;
    "A B" skips the SPACE node and translates 'B' past it.
  - `tests/round7_bitmap_glyph_node.rs` — Noto Color Emoji
    `glyph_node('🎉', 96.0)` must be `Node::Image(ImageRef)` with
    a non-empty RGBA plane and ≥1 non-zero-alpha pixel.

### Added — round 5, CBDT/CBLC color bitmap glyphs (2026-05-04)

- New `color_glyph` module + `ColorGlyphBitmap { bitmap, bearing_x,
  bearing_y, advance, ppem }` carrying a decoded RGBA bitmap plus the
  metrics needed for placement.
- `Face::has_color_bitmaps() -> bool` — wraps
  `oxideav_ttf::Font::has_color_bitmaps`. Short-circuits for OTF
  faces (no CFF font we've seen ships CBDT).
- `Face::color_strike_sizes() -> Vec<(u8, u8)>` — all `(ppem_x,
  ppem_y)` strikes the face declares; empty when no CBDT.
- `Face::raster_color_glyph(glyph_id, size_px) -> Result<Option<
  ColorGlyphBitmap>, Error>` — picks the closest strike to
  `size_px.round()`, walks CBLC to find the glyph entry, hands the
  raw PNG bytes from CBDT to `oxideav_png::decode_png_to_frame`, and
  unwraps the `VideoFrame` into an `RgbaBitmap`. PNG width/height
  are recovered directly from the IHDR chunk so the bytes-per-pixel
  ratio is unambiguous (no heuristic: stride / width gives the
  right answer for Rgba8 / Rgb24 / Ya8 / Gray8).
- `oxideav-png` added as a dependency of `oxideav-scribe`. NO `png` /
  `image` crate per workspace policy.
- `tests/round5_emoji.rs` integration test against
  `NotoColorEmoji.ttf` (10.6 MB; download-on-demand via the same
  fixture cache as the CJK test). Verifies the font loads (which
  pre-round-5 would fail because Noto Color Emoji has no `glyf`/
  `loca`), `has_color_bitmaps()` is true, U+1F389 PARTY POPPER
  resolves through cmap, the CBDT walker hands back a non-empty
  PNG payload, the rasterised RGBA bitmap has >5% non-zero alpha
  pixels, and `Shaper::shape("🎉 ok")` survives the no-outline
  shaping path.

### Added — round 5, TTC support + CJK fallback integration test (2026-05-04)

- `Face::from_ttc_bytes(bytes, index)` — construct a face from the
  `index`-th subfont of a TrueType Collection (TTC / `'ttcf'`). Stores
  the subfont index on the face so that `with_font` re-parses through
  `oxideav_ttf::Font::from_collection_bytes(bytes, i)` instead of
  `from_bytes` and the right subfont is selected each time.
- `Face::subfont_index() -> Option<u32>` — accessor; `None` for plain
  sfnt-flavour faces.
- New dev-dep on `ureq = "3"` for the integration-test fixture
  downloader (mirrors the `oxideav-msmpeg4` pattern).
- New `tests/font_fixtures/mod.rs` — shared download-cache-verify
  helper used by all round-5 integration tests. Caches under
  `target/test-fixtures/fonts/`, gates first-time downloads behind
  `OXIDEAV_NETWORK_TESTS=1`, SHA-256 verifies on every load. Skips
  silently with `eprintln!` when neither cached nor enabled.
- `tests/round5_cjk_fallback.rs` closes the round-2 deferral
  ("Two-script-coverage fallback integration test"). Loads
  NotoSansCJK-Medium.ttc subfont 0 (Japanese cut) as the fallback
  behind DejaVu Sans Mono, shapes `"hello 日本語 world"` through a
  `FaceChain`, and asserts:
  - Each Latin codepoint resolves to face_idx 0 (DejaVu).
  - Each CJK codepoint resolves to face_idx 1 (Noto CJK) with a
    non-zero glyph id.
  - The total run advance is positive and CJK glyphs are on average
    wider than Latin glyphs (east-asian wide sanity).

### Added — round 4, oblique fixture for italic-on-italic suppression (2026-05-04)

- `tests/fixtures/DejaVuSansMono-Oblique.ttf` (252 KB) — DejaVu Sans
  Mono Oblique with `post.italicAngle = -11.0°`. Shipped under the
  same Bitstream Vera license as the other DejaVu fixtures
  (DEJAVU-LICENSE already in tests/fixtures/).
- New integration test `round4_oblique.rs` verifies that the
  round-2 deferral is closed:
  - `Face::italic_angle()` round-trips `-11.0°` from the parser.
  - `synthetic_italic_shear(Style::italic(), face.italic_angle())`
    returns 0 on the oblique face — no double-shear synthesis.
  - `render_text_styled(face, "I", 32, WHITE, Style::REGULAR)` and
    `render_text_styled(face, "I", 32, WHITE, Style::italic())`
    produce *bit-identical* RGBA bitmaps on the oblique face.
  - The same italic() request on the matching upright fixture
    DOES synthesise a wider 'I' — confirming the asymmetry survives
    end-to-end.
  - A REGULAR request on the oblique face still renders the font's
    own forward slant (top-right quadrant alpha sum exceeds the
    upright fixture's).

### Added — round 4, GPOS mark-to-mark stacking (2026-05-04)

- Shaper now runs a 5th pass after mark-to-base: for each consecutive
  `(mark_prev, mark_new)` pair where both glyphs are GDEF marks,
  `oxideav_ttf::Font::lookup_mark_to_mark(prev, new)` is consulted.
  If the font ships an anchor for the pair, the new mark is positioned
  relative to the previous mark's *post-attachment* position (which
  already sits on the base). This handles double-diacritic stacks
  like Vietnamese `ê + acute → ế` and polytonic Greek
  `α + tonos + dialytika`.
- Round-3 mark-to-base remains the fallback for any pair the font
  doesn't cover with a mark-to-mark anchor (most fonts ship a sparse
  set of mark-to-mark anchors compared to mark-to-base).
- New integration test `round4_marks.rs` verifies that
  `e + COMBINING CIRCUMFLEX + COMBINING ACUTE` stacks the acute
  ABOVE the circumflex (proving mark-to-mark fired, not the
  round-3 fallback which would overlap them); that the gap scales
  linearly with `size_px`; and that the round-3 single-mark path is
  unaffected.

### Added — round 3, synthetic bold via alpha dilation (2026-05-04)

- `style::synthetic_bold_radius(style, face_weight, size_px) -> f32`
  — when the requested `style.weight` exceeds the face's natural
  `usWeightClass` by at least `SYNTHETIC_BOLD_THRESHOLD = 200` (two
  weight steps), returns the per-side dilation radius in pixels.
  Formula: `0.0001 * size_px * weight_delta`, clamped up to 1.0 px
  so the dilation kernel produces visible thickening at small body
  sizes. For Regular (400) → Bold (700) at 32 px this yields ~1.0
  px (clamped from 0.96), at 64 px ~1.92 px, matching what
  Microsoft GDI+ and libass produce for ASS `\b1` against a Regular
  face.
- `style::SYNTHETIC_BOLD_THRESHOLD = 200` and
  `SYNTHETIC_BOLD_PX_PER_WEIGHT_STEP_PER_PX = 0.0001` — tunable
  constants exposed for callers that need a different aesthetic.
- `Composer::compose_run` / `compose_run_styled` /
  `compose_run_with_stroke` — apply the synthetic-bold radius to
  the cached glyph bitmap on the fly, combined additively with any
  stroke radius, so a Bold + bordered cue gets a thick stroke
  surrounding a thick fill.
- `render_text_styled` — top-level entry point honours synthetic
  bold via the same dilation path.
- Caveat: callers that have a real Bold face available SHOULD prefer
  loading it as a separate `Face`; synthetic bold is the fallback
  for fonts that ship only one cut. The cache key already includes
  `weight` indirectly via the face id, so loading a real Bold face
  produces a separate cache slot from the Regular one.

### Added — round 3, GPOS mark-to-base attachment (2026-05-04)

- Shaper now runs a 4th pass after kerning: for each `(base, mark)`
  pair where `mark` is classified as a mark by the font's `GDEF`
  table, it queries `oxideav_ttf::Font::lookup_mark_to_base(base,
  mark)` and applies the returned anchor delta to the mark's
  `x_offset` / `y_offset`. The mark's `x_advance` is zeroed so a
  following glyph lands at the post-base pen position, matching what
  every desktop shaper does. Multi-mark stacks (e.g. polytonic
  Greek `α + tonos + dialytika`) work because each mark walks back
  through previous marks until a base is found.
- Y axis is converted from TT (Y-up) to raster (Y-down) at the
  shaper boundary so consumers don't have to think about it.
- No public-API change: `PositionedGlyph` already had `y_offset`
  from round 1.
- New integration test `round3_marks.rs` verifies `'A' + U+0301` →
  combining acute lifts above the baseline (negative raster Y
  offset), the mark's advance is zeroed, the offset scales linearly
  with `size_px`, and pure-base runs are untouched.

### Added — round 3, sub-pixel positioning (2026-05-04)

- `cache::SUBPIXEL_STEPS = 16` + `subpixel_slot(x_fract)` +
  `subpixel_offset(slot)` — quantise the fractional part of a pen X
  position to one of 16 sub-pixel positions per pixel. The composer
  uses these to bake the sub-pixel placement into the cached glyph
  bitmap, then blits at `floor(pen_x)`. Result: visibly cleaner edges
  at 12–14 px body sizes than naive integer rounding.
- `GlyphKey { ..., x_subpixel_q4: u8 }` + `GlyphKey::new_subpixel(...)`
  — extends the LRU key with the sub-pixel slot. Each unique
  `(face, glyph, size, shear)` tuple now occupies up to 16 cache
  slots; in practice ~3-4 are touched per glyph in typical text and
  the 256-entry default still holds an entire cue.
- `Rasterizer::raster_glyph_subpixel(face, gid, size_px, shear,
  x_subpixel)` + `Rasterizer::glyph_offset_subpixel(...)` — outline
  is shifted right by `x_subpixel` pixels before flatten, so the
  resulting alpha pattern reflects the sub-pixel placement. The
  bitmap left edge stays floor-aligned so the composer can blit at
  integer X.
- `outline::flatten_with_shear_offset(...)` — the underlying flatten
  helper that takes the shear + sub-pixel arguments. Bit-identical to
  `flatten_with_shear` when `x_subpixel == 0.0`.
- `render_text_styled` now uses sub-pixel positioning automatically;
  `Composer::compose_run` / `compose_run_styled` /
  `compose_run_with_stroke` likewise. Existing callers see a quality
  improvement with no API changes.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).