### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.2...v0.1.3) - 2026-05-04
+
+### Other
+
+- wrap shape_to_paths glyphs in cache-keyed Group ([#357](https://github.com/OxideAV/oxideav-scribe/pull/357))
+- implement trapezoidal horizontal coverage for sub-pixel AA
+- re-enable round4 double-diacritic, assert acute < circumflex
+- re-enable round7 path test, switch glyph 'A' -> 'O'
+
 ### Added
 
 - `Face::stable_id()` — content-derived face identity (DefaultHasher

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-scribe"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-scribe`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.2...v0.1.3) - 2026-05-04

### Other

- wrap shape_to_paths glyphs in cache-keyed Group ([#357](https://github.com/OxideAV/oxideav-scribe/pull/357))
- implement trapezoidal horizontal coverage for sub-pixel AA
- re-enable round4 double-diacritic, assert acute < circumflex
- re-enable round7 path test, switch glyph 'A' -> 'O'

### Added

- `Face::stable_id()` — content-derived face identity (DefaultHasher
  digest of the leading sfnt bytes + length + subfont index) that is
  stable across loads of the same font bytes. Distinct from the
  per-process `Face::id()` counter, this is the right input for any
  cache key persisted across renderer instances or program runs.
- `Shaper::shape_to_paths` now wraps each emitted glyph node in a
  `Node::Group { cache_key: Some(_), children: vec![glyph_node], .. }`
  carrier with a deterministic `cache_key` derived from
  `(face_stable_id, glyph_id, size_q8)`. Combined with oxideav-raster's
  composite-key bitmap cache (which mixes the producer key with the
  effective transform), this lets the rasterizer reuse the same
  bitmap for repeated glyph instances across a run, across renderers,
  and across program restarts. Closes #357.

### Changed

- Bumped `oxideav-core` minimum to `0.1.15` for the `Group::cache_key`
  field used by the new `shape_to_paths` wrapper.
- `tests/round7_shape_to_paths.rs`: updated to expect the new
  `Node::Group { cache_key: Some(_), children: [PathNode] }`
  envelope around each glyph instead of the raw `Node::Path`.

### Fixed

- `tests/round7_glyph_path.rs`: switched test glyph from 'A' to 'O'.
  DejaVu Sans Mono's 'A' is a pure 13-command polygon (zero curves),
  so the `QuadCurveTo ≥ 1` assertion never held. 'O' is the canonical
  curve-bearing glyph and exercises the TT quadratic outline path.
  Test re-enabled.
- `tests/round4_marks.rs::double_diacritic_stacks_above_first`: replaced
  the `circumflex.y_offset < 0` assertion (which was incorrect — the
  shaper's `y_offset` is a *delta* from the natural pen position, not an
  absolute raster Y, and DejaVu Sans's (e, circumflex) anchor pair has
  dy = 0) with `acute.y_offset < circumflex.y_offset`. This is the
  actual round-4 invariant: the second mark stacks STRICTLY above the
  first via the (mark1, mark2) anchor, vs. the round-3 fallback which
  would attach both marks to the base at the same anchor (overlap).
  Test re-enabled.

### Changed

- Rasterizer: replaced binary `floor`/`ceil` horizontal scanline fill
  with **analytical trapezoidal coverage**. Each non-vertical active-
  edge pair now contributes per-pixel fractional coverage
  `clamp(min(x1, px+1) - max(x0, px), 0, 1)` (mapped to a 0..=255
  byte), accumulated into the supersample buffer instead of a hard
  `0`/`1`. The 4× vertical supersample is unchanged. Effect: 16
  sub-pixel x-slots now produce 16 visually distinct glyph bitmaps
  (previously they collapsed to ~2 because horizontal edges were
  binary). Re-enables `round3_subpixel::different_slots_produce_*` and
  `each_slot_produces_a_distinct_bitmap`.
- `outline::flatten_with_shear_offset`: consolidated bbox computation
  so the bitmap dimensions are *independent* of `x_subpixel`. The
  bitmap left edge is always `floor(raw.x_min * scale)` and the bitmap
  right edge always reserves a 1-px slack column for the trapezoidal
  rightmost partial-coverage. Without this every sub-pixel slot would
  pick a different bitmap width as the silhouette spilled across pixel
  boundaries. Glyph bitmaps are typically 1 px wider than before
  (round-2 callers see at most a 1-column right-edge zero pad).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).