### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.4...v0.1.5) - 2026-05-04
+
+### Other
+
+- Bengali + Tamil + reph GSUB wiring (round 10)
+- variable-font axis selection (round 9)
+- add Arabic + Devanagari rows to capability list
+- Devanagari complex-script cluster reorder (round 8)
+- Arabic contextual joining (round 7)
+- drop pixel pipeline — vector-only refactor ([#354](https://github.com/OxideAV/oxideav-scribe/pull/354))
+
 ### Added — Bengali + Tamil shaping + reph GSUB wiring (round 10)
 
 Round 10 extends Indic complex-script shaping beyond Devanagari

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-scribe"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-scribe`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.4...v0.1.5) - 2026-05-04

### Other

- Bengali + Tamil + reph GSUB wiring (round 10)
- variable-font axis selection (round 9)
- add Arabic + Devanagari rows to capability list
- Devanagari complex-script cluster reorder (round 8)
- Arabic contextual joining (round 7)
- drop pixel pipeline — vector-only refactor ([#354](https://github.com/OxideAV/oxideav-scribe/pull/354))

### Added — Bengali + Tamil shaping + reph GSUB wiring (round 10)

Round 10 extends Indic complex-script shaping beyond Devanagari
(round 8 baseline) to two more scripts and wires the long-deferred
reph GSUB substitution.

- `shaping::indic::bengali_category(char) -> IndicCategory` — Bengali
  (U+0980..U+09FF) syllabic categorisation. Bengali shares
  Devanagari's structural shape (halant U+09CD glues consonants into
  conjuncts; bindus attach to the cluster end) but has THREE pre-base
  reordering matras (U+09BF "i", U+09C7 "e", U+09C8 "ai") instead of
  Devanagari's one. The reph rule is the same — RA U+09B0 + halant +
  consonant.
- `shaping::indic::tamil_category(char) -> IndicCategory` — Tamil
  (U+0B80..U+0BFF) syllabic categorisation. Minimal cluster machine:
  no nukta (no U+0BBC slot), no reph (Tamil RA does not form a
  superscript), no conjunct formation in the modern orthography.
  Three pre-base matras (U+0BC6 / U+0BC7 / U+0BC8 — e / ee / ai).
- `shaping::indic::ReorderRules { category, ra_codepoint, reph_enabled }`
  + `DEVANAGARI_RULES` / `BENGALI_RULES` / `TAMIL_RULES` constants —
  per-script reorder rule descriptors. The cluster machine
  (`reorder_cluster_with`) and segmenter (`cluster_boundaries_with`)
  are now generic over a `ReorderRules` reference, so adding
  Telugu / Gujarati / Gurmukhi / Kannada / Malayalam / Oriya in
  future rounds is a one-table change rather than a re-implementation.
- `shaping::indic::bengali_feature_tags()` /
  `shaping::indic::tamil_feature_tags()` — per-script OpenType GSUB
  feature application order. Bengali shares Devanagari's tag list
  one-to-one (same Indic family rules); Tamil's list omits `rphf` /
  `cjct` / `vatu` and adds the Tamil-specific `pref` (pre-base form,
  reorders the pre-base component of a precomposed two-part vowel
  sign).
- `shaping::indic::script_indic_tags(Script) -> Option<([u8; 4], [u8; 4])>`
  — maps a script to its `(modern, legacy)` OpenType script tag pair
  (`dev2` / `deva`, `bng2` / `beng`, `tml2` / `taml`). The `rphf`
  feature lookup walks BOTH tags so older fonts that only ship the
  v1 tag still get the reph substitution.
- `Script::Bengali` / `Script::Tamil` — added to
  `shaping::arabic::Script`. The shared `script_of(char)` classifier
  now returns them for the U+0980..U+09FF / U+0B80..U+0BFF blocks;
  `feature_tags_for_run(Script::Bengali / Script::Tamil)` returns
  the matching tag list.
- `FaceChain::shape` (and `shape_styled`) gained a generalised
  pre-cmap pass `apply_indic_reorder` that finds contiguous Indic
  runs of one script at a time and dispatches per-script reorder
  rules. The previous round-8 `apply_devanagari_reorder` is replaced.
- **Reph GSUB substitution wired (round 8 followup).** When the
  cluster machine flags `ClusterFlags::has_reph` AND the face
  assigned to the RA glyph publishes a `rphf` GSUB feature for the
  active script, `Font::gsub_apply_lookup_type_1` is applied to the
  RA glyph; on success, the RA gid is replaced with the reph form
  and the halant glyph is removed from the run. Faces without an
  `rphf` lookup fall back to in-line RA + halant + base rendering
  (the round-8 behaviour). The substitution is back-to-front order
  so multiple reph clusters in one run don't shift the indexing of
  pending marks.

The implementations are clean-room readings of:

- Unicode 15.1 Standard Annex #15 (Indic syllabic categories).
- Microsoft OpenType Layout — *Creating and supporting OpenType
  fonts for Indic scripts* (Bengali / Tamil / Telugu / Gujarati /
  Gurmukhi / Kannada / Malayalam / Oriya).

No HarfBuzz / FreeType / pango / ICU layout source consulted.

Test coverage:
- `shaping::indic::tests` — 21 new unit tests covering Bengali +
  Tamil categorisation, per-script pre-base matra reorder, Bengali
  reph identification, Tamil reph-disabled assertion, per-script
  feature-tag lists, and `script_indic_tags` mapping. Total
  `shaping::indic` test count: 49 (up from 26).
- `face_chain::tests` — 7 new unit tests covering the multi-script
  pre-cmap pass: Bengali pre-base matra reorder, Bengali reph mark
  with the right script tag, Tamil pre-base reorder, Tamil
  no-reph-mark assertion, Devanagari reph mark indexing (with and
  without a coexisting pre-base matra reorder), and a mixed
  Devanagari + Bengali run that segments cleanly at the script
  boundary.
- `tests/round10_bengali_cluster.rs` /
  `tests/round10_tamil_cluster.rs` — integration tests skip with
  `eprintln!` on the current vendored fonts (DejaVuSans does not
  cover Bengali / Tamil), exactly mirroring the round-8 Devanagari
  pattern. Activates once `NotoSansBengali-Regular.ttf` (~290 KB,
  OFL) / `NotoSansTamil-Regular.ttf` (~330 KB, OFL) lands in
  `samples.oxideav.org/fonts/` via the `font_fixtures` helper.

Followup tasks deferred:
- **Devanagari fixture font on the CDN.** Activating the round-8
  `ki_cluster_reorders_pre_base_matra_before_base` integration test
  needs `NotoSansDevanagari-Regular.ttf` (~280 KB, OFL) on
  `samples.oxideav.org/fonts/`. The `font_fixtures` helper plumbing
  is in place — adding the fixture is one entry in the `pub const`
  table plus a `tests/round8_devanagari_cluster.rs` switch from
  `include_bytes!` to `load_fixture(..)`. Same for the round-10
  Bengali / Tamil tests.
- **Remaining Indic scripts.** Telugu (U+0C00..U+0C7F — split
  vowels including U+0C46 + U+0C56), Gujarati (U+0A80..U+0AFF —
  closest to Devanagari), Gurmukhi (U+0A00..U+0A7F), Kannada
  (U+0C80..U+0CFF), Malayalam (U+0D00..U+0D7F), Oriya
  (U+0B00..U+0B7F). Each is a per-script categorisation table +
  `ReorderRules` constant.
- **Other GSUB features (`pref`, `pres`, `blwf`, `blws`, `half`,
  `cjct`, etc.).** Round 10 wires only `rphf`. The remaining
  Indic substitution features follow the same gsub_features_for_script
  + `gsub_apply_lookup_type_1` pattern but need cluster-position
  awareness (e.g. `half` only applies to non-final consonants).

### Added — variable-font axis selection in shaping (round 9)

scribe now lets callers shape a run against a specific
`fvar`-axis-coord vector, so a single Inter Variable / Roboto Flex /
Source Sans 3 VF font can be rendered at e.g. `wght=600 / wdth=125`
without loading a separate static cut. The path-output reflects the
gvar deltas applied at the chosen coords.

- `Face::is_variable()` / `Face::variation_axes()` /
  `Face::named_instances()` / `Face::variation_coords()` /
  `Face::set_variation_coords(coords)` / `Face::clear_variation_coords()`
  — variation-coord state lives on `Face`. The vector is stored
  alongside the owned font bytes and re-applied on every
  `Face::with_font` re-parse so subsequent `glyph_path` /
  `glyph_node` / `glyph_advance` lookups see the gvar-blended
  outline. `set_variation_coords` round-trips through the underlying
  parser to preserve its `[min, max]` clamp + per-axis length cap.
- `FaceChain::set_variation_coords(coords)` /
  `FaceChain::variation_axes(face_index)` /
  `FaceChain::named_instances(face_index)` /
  `FaceChain::face_mut(idx)` — chain-level mirrors. The setter
  targets the **primary** face only; fallback faces typically cover a
  different script and are loaded from a static cut, so flipping a
  fallback's coords requires `chain.face_mut(idx).set_variation_coords(..)`
  explicitly.
- `Shaper::with_variation_coords(Vec<f32>) -> ShaperBuilder` —
  per-call override builder. `ShaperBuilder::shape` /
  `ShaperBuilder::shape_to_paths` install the coords on the primary
  face for the duration of the call, run the shape, then restore the
  pre-call coord vector (or clear it when the chain had never had
  any). The static `Shaper::shape` / `Shaper::shape_to_paths` entry
  points are unchanged — they continue to use whatever coords are
  currently installed on the chain (axis defaults if none).
- `Shaper::named_instances(face_chain, face_index)` — convenience
  pass-through accessor that returns `Vec<NamedInstance>` for the
  chosen face. Each `NamedInstance` carries a `coords` vector that
  matches the face's `variation_axes` one-to-one; callers pick the
  vector that defines "Regular" / "Bold" / etc and pass it to
  `Face::set_variation_coords` or `Shaper::with_variation_coords`.
  Resolving the human-readable subfamily label requires reading the
  `name` table directly via `Face::with_font` — scribe deliberately
  doesn't surface a `name_id → string` accessor (the underlying ttf
  `Font::name` field is private).
- `oxideav_ttf::VariationAxis` and `oxideav_ttf::NamedInstance` are
  re-exported from the crate root so callers don't need to depend on
  `oxideav-ttf` directly.

The implementation is a clean-room consumer of `oxideav-ttf`'s
existing `fvar` / `avar` / `gvar` stack (which was a clean-room
implementation of OpenType 1.9 §6.2 / §6.3 / §6.5). No HarfBuzz /
FreeType / fontTools / Skia variable-font source consulted.

Integration test (`tests/round9_variable_font.rs`) loads
`InterVariable.ttf` (vendored OFL fixture) and verifies:
- Axes / named-instance counts match Inter (2 axes, 9 instances).
- `with_variation_coords([opsz_default, 400.0]).shape_to_paths(..)`
  vs `[opsz_default, 900.0]` produces glyph outlines whose
  per-coordinate points differ (gvar deltas applied).
- The chain's pre-call coord vector is restored after the builder
  returns (empty stays empty).
- A `Shaper::named_instances` lookup picks out the instance whose
  coords match every axis default (the canonical "Regular").
- `Face::set_variation_coords` clamps below-min / above-max coords
  to each axis's `[min, max]` and leaves in-range values untouched.
- Shaping against the explicit axis-default coords reproduces the
  static `Shaper::shape_to_paths` output bit-exactly.

Followup tasks deferred:
- Variable-CFF2 / OTF support — `Face::set_variation_coords` rejects
  OTF faces (`WrongFaceKind`) until `oxideav-otf` exposes a CFF2
  variation pipeline.
- Variable-font *metrics* (`MVAR`, `HVAR`, `VVAR`, `STAT`) —
  `Face::ascent_px` / `descent_px` / `line_height_px` /
  `glyph_advance` (via the shaper) currently use `head` / `hhea` /
  `OS/2` static values. Once `oxideav-ttf` exposes `MVAR` / `HVAR`
  blending, scribe will route these through the same coord vector.
- Per-fallback-face variation coords convenience — currently
  callers reach through `FaceChain::face_mut(idx)`.

Test fixture: `tests/fixtures/InterVariable.ttf` — a copy of the
same Inter Variable cut vendored by `oxideav-ttf/tests/fixtures/`,
plus the matching `INTER-OFL-LICENSE.txt`. ~843 KB.

### Added — Devanagari complex-script shaping (round 8)

New `shaping::indic` module covering Devanagari (Hindi / Marathi /
Sanskrit / Nepali) cluster-based shaping:

- `shaping::indic::IndicCategory` + `devanagari_category(char)` —
  Devanagari syllabic categorisation derived from the Unicode
  `IndicSyllabicCategory.txt` + `IndicPositionalCategory.txt`
  properties, condensed to the categories the cluster machine
  distinguishes (Consonant, Vowel, Halant, PreBaseMatra, Matra,
  Nukta, Bindu, Symbol, Other).
- `shaping::indic::cluster_boundaries(&[char]) -> Vec<(usize, usize)>`
  — segments the input into Devanagari orthographic clusters.
  Halant glues the next consonant into the same cluster (forming a
  conjunct); independent vowels and consonants without a preceding
  halant start new clusters; danda + non-Indic codepoints always
  form cluster boundaries.
- `shaping::indic::reorder_cluster(&[char]) -> (Vec<char>, ClusterFlags)`
  — applies the round-8 cluster transformations: pre-base matra
  reordering (U+093F moves to the front of the cluster, ahead of its
  base consonant) and reph identification (a leading
  RA + halant + consonant sets `ClusterFlags::has_reph`).
- `shaping::indic::devanagari_feature_tags()` — the spec-mandated
  Devanagari OpenType feature tag list in application order
  (`locl`, `ccmp`, `nukt`, `akhn`, `rphf`, `blwf`, `half`, `vatu`,
  `cjct`, `init`, `pres`, `abvs`, `blws`, `psts`, `haln`).
  Returned as `Vec<[u8; 4]>` so the future GSUB feature-lookup pass
  can iterate without re-deriving the order.
- `Script::Devanagari` — added to `shaping::arabic::Script`. The
  shared `script_of(char)` classifier now returns it for the
  U+0900..U+097F block; `feature_tags_for_run(Script::Devanagari)`
  returns the Devanagari feature-tag list.
- `FaceChain::shape` (and `shape_styled`) gained a second pre-cmap
  shaping pass that runs after the round-7 Arabic substitution.
  Devanagari runs are segmented into clusters and each cluster's
  characters are reordered into visual order before face-chain cmap
  lookup. A simple cmap-only Devanagari font therefore renders
  "कि" (KA + sign-i) with the matra correctly placed visually before
  the base consonant — without needing feature-tagged GSUB lookups.

The reph glyph substitution (the `rphf` GSUB feature) is *flagged*
but not yet emitted; the substitution requires `oxideav-ttf` to
expose feature-tagged GSUB lookup type 1 (single substitution),
which is being implemented in parallel. Once that lands, scribe will
consume the `has_reph` flag plus the `devanagari_feature_tags()`
feature list to drive the substitution.

The implementation is a clean-room reading of:

- Unicode 15.1 Standard Annex #15 (Indic syllabic categories)
- Unicode 15.1 Standard Annex #29 (text segmentation)
- Microsoft OpenType Layout — *Creating and supporting OpenType
  fonts for the Devanagari script*

No HarfBuzz / FreeType / pango / ICU layout source consulted.

Integration test (`tests/round8_devanagari_cluster.rs`) is in place
but *skips* on the current vendored fonts — DejaVuSans does not
cover the Devanagari block. Adding `NotoSansDevanagari-Regular.ttf`
(OFL-licensed; ~280 KB) to the `samples.oxideav.org/fonts/`
network-fetch CDN via the `font_fixtures` helper will activate the
test. Unit tests cover the cluster machine + reorder
exhaustively (26 new tests in `shaping::indic::tests` plus 5 in
`face_chain::tests`).

Followup tasks deferred:
- Other Indic scripts (Bengali U+0980..U+09FF, Gurmukhi U+0A00..U+0A7F,
  Gujarati U+0A80..U+0AFF, Tamil U+0B80..U+0BFF, Telugu U+0C00..U+0C7F,
  Kannada U+0C80..U+0CFF, Malayalam U+0D00..U+0D7F) — same broad
  cluster-machine shape but per-script categories, pre-base
  reordering matras, and feature lists.
- Reph glyph substitution via `rphf` GSUB once `oxideav-ttf`
  exposes feature-tagged GSUB lookup type 1.
- Vertical text (`vert` / `vrt2` features for CJK).
- GPOS cursive attachment (`curs` feature) — needed for proper
  Arabic / Devanagari mark positioning beyond simple anchor delta.

### Added — Arabic contextual joining (round 7)

New `shaping` module covering Arabic / Hebrew RTL contextual shaping:

- `shaping::arabic` — Unicode joining-class lookup (`JoiningClass::{U,
  L, R, D, C, T}`) covering the Arabic + Syriac + Arabic Supplement +
  Arabic Extended-A blocks plus combining-mark transparents, and the
  joining-adjacency state machine `compute_forms(&[char]) ->
  Vec<JoiningForm>` that picks `Isol` / `Init` / `Medi` / `Fina` per
  character (transparent marks inherit the form of the preceding base;
  ZWJ acts as joining-causing; ZWNJ breaks the chain).
- `shaping::arabic::script_of(char) -> Script` and
  `feature_tags_for_run(Script) -> Vec<[u8; 4]>` — script
  classification + the OpenType feature-tag list for a run (Arabic gets
  `isol` / `init` / `medi` / `fina`).
- `shaping::arabic_pf::presentation_form(base, JoiningForm) ->
  Option<char>` — translates an Arabic base codepoint + chosen form
  into its Arabic Presentation Forms-B equivalent (U+FE70..U+FEFF) per
  the UCD `UnicodeData.txt` `<initial>` / `<medial>` / `<final>` /
  `<isolated>` decomposition tags.
- `FaceChain::shape` (and `shape_styled`) now run a pre-cmap shaping
  pass that finds Arabic codepoint runs, picks the contextual form per
  letter, and rewrites to the PF-B equivalent before face-chain cmap
  lookup. The shaper's existing GSUB ligature pass then collapses
  LAM-medi + ALEF-fina into the LAM-ALEF FINAL ligature (U+FEFC) for
  fonts that ship it (DejaVuSans does). Faces that lack a PF-B glyph
  fall back to the original base codepoint — the shaper degrades to
  the round-6 isolated-form behaviour rather than emitting `.notdef`.

The substitution is a clean-room implementation of the algorithm
described in Unicode core specification §9.2 and the OpenType layout
spec for the four Arabic feature tags. No HarfBuzz / FreeType / pango
/ ICU layout source consulted.

Integration test (`tests/round7_arabic_joining.rs`) shapes "السلام"
against DejaVuSans and asserts the resulting glyph IDs match the
PF-B + LAM-ALEF-ligature gids, demonstrably differing from the naive
isolated-form lookup.

Followup tasks deferred:
- Full feature-tagged GSUB lookup table (lookup type 1 single
  substitution) — needed for fonts that don't ship the PF-B block but
  do ship feature lookups (e.g. modern Noto Sans Arabic UI).
- Mark reordering + GPOS mark-attachment per Arabic shaper rules.
- Indic complex-script shaping (round 8 candidate).

### Removed — vector-only refactor (#354)

Scribe is now a pure vector shaper. All pixel-pipeline code moved to
[`oxideav-raster`](https://github.com/OxideAV/oxideav-raster); consumers
that need a rasterised text run should call `Shaper::shape_to_paths`,
wrap the resulting nodes in a `VectorFrame`, and hand it to
`oxideav_raster::Renderer::render`.

Removed modules: `cache`, `compose`, `outline`, `rasterizer`, `stroke`.

Removed public APIs:
- `render_text` / `render_text_styled` / `render_text_wrapped`
- `Composer` / `Composer::compose_run` / `compose_run_styled` /
  `compose_run_with_stroke` / `with_capacity` / `cache` accessors
- `StrokeStyle`
- `Rasterizer` / `Rasterizer::raster_glyph` / `raster_glyph_styled` /
  `raster_glyph_subpixel` / `glyph_offset*`
- `AlphaBitmap`
- `RgbaBitmap` (the public re-export from the crate root — the type
  itself still lives at `oxideav_scribe::color_glyph::RgbaBitmap` as
  the carrier for the CBDT decode path; vector consumers will not need it)
- `outline::flatten` / `flatten_with_shear` / `flatten_with_shear_offset` /
  `flatten_cubic` / `flatten_cubic_with_shear` / `FlatOutline` / `FlatBounds`
- `cache::GlyphKey` / `GlyphCache` / `CachedGlyph` /
  `subpixel_slot` / `subpixel_offset` / `SUBPIXEL_STEPS`
- `stroke::dilate_alpha` / `dilate_offset`
- `style::synthetic_bold_radius` /
  `style::SYNTHETIC_BOLD_THRESHOLD` /
  `style::SYNTHETIC_BOLD_PX_PER_WEIGHT_STEP_PER_PX`
- `face_chain::shear_for`

Removed dependency: `oxideav-pixfmt` (the alpha-blit responsibility
moves to the rasterizer).

`Style` keeps `weight: u16` for downstream rasterizers wanting to
synthesise bold; scribe itself no longer applies bold dilation.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).