### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.7...v0.1.8) - 2026-05-30
+
+### Other
+
+- UAX #9 weak-type resolution rules W1..W7 (round 191)
+- UAX #9 BiDi foundation — character classes + P1/P2/P3 paragraph level (round 186)
+- caller-driven Type-3 alternate-index selection (round 183)
+- round175 tests: use scribe-local DejaVu fixture (CI fix)
+- explicit-script-tag entry point + broadened auto-probe (round 175)
+- GSUB LookupType 3 (Alternate Substitution) wired into shape_text (round 156)
+- GSUB LookupType 4 (Ligature Substitution) wired into shape_text (round 128)
+- GSUB LookupType 2 (Multiple Substitution) wired into shape_text (round 125)
+- GSUB LookupType 1 caller-driven feature application (round 89)
+- GSUB feature-tag introspection on Face (round 88)
+- general-script ccmp + calt GSUB pass (round 15)
+- hygiene round 75 (Error::source, lib.rs doc refresh, no_run doctests)
+- drop committed Cargo.lock + relax oxideav-core to "0.1"
+- backfill Unreleased entry for round 14 + round 13
+- variable fonts (CFF2/MVAR/HVAR/VVAR/STAT/name_id) + Brahmic round 13 (Burmese + Lao)
+
 ### Added — UAX #9 §3.3.4 weak-type resolution rules W1..W7 on the BiDi foundation (round 191)
 
 Second concrete UAX #9 surface on scribe lands on top of the round

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-scribe"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-scribe`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.8](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.7...v0.1.8) - 2026-05-30

### Other

- UAX #9 weak-type resolution rules W1..W7 (round 191)
- UAX #9 BiDi foundation — character classes + P1/P2/P3 paragraph level (round 186)
- caller-driven Type-3 alternate-index selection (round 183)
- round175 tests: use scribe-local DejaVu fixture (CI fix)
- explicit-script-tag entry point + broadened auto-probe (round 175)
- GSUB LookupType 3 (Alternate Substitution) wired into shape_text (round 156)
- GSUB LookupType 4 (Ligature Substitution) wired into shape_text (round 128)
- GSUB LookupType 2 (Multiple Substitution) wired into shape_text (round 125)
- GSUB LookupType 1 caller-driven feature application (round 89)
- GSUB feature-tag introspection on Face (round 88)
- general-script ccmp + calt GSUB pass (round 15)
- hygiene round 75 (Error::source, lib.rs doc refresh, no_run doctests)
- drop committed Cargo.lock + relax oxideav-core to "0.1"
- backfill Unreleased entry for round 14 + round 13
- variable fonts (CFF2/MVAR/HVAR/VVAR/STAT/name_id) + Brahmic round 13 (Burmese + Lao)

### Added — UAX #9 §3.3.4 weak-type resolution rules W1..W7 on the BiDi foundation (round 191)

Second concrete UAX #9 surface on scribe lands on top of the round
186 character-class + paragraph-level foundation: the complete W
phase from §3.3.4. The phase resolves one isolating run sequence
end-to-end, leaving the slice with no `AL` (W3 collapses every one
to `R`) and no leftover `ES` / `ET` / `CS` (W6 collapses every
remainder to `ON`) — i.e. a clean vocabulary for the upcoming
N-rules and the §3.3.6 implicit-level rules.

- **`bidi::resolve_weak_types(classes: &mut [BidiClass], sos:
  BidiClass, eos: BidiClass)`** — in-place pass over one isolating
  run sequence applying the seven rules in order:
  - **W1** — `NSM` inherits the type of the immediately-preceding
    character. NSM at the start of the sequence takes the `sos` type.
    NSM after an isolate initiator (`LRI` / `RLI` / `FSI`) or after
    `PDI` becomes `ON`. The forward pass means consecutive NSMs all
    flip to the same final type (per the spec example `AL NSM NSM →
    AL AL AL`).
  - **W2** — `EN` whose most-recent strong type (walking backward
    through neutrals etc., with `sos` as the implicit start) is `AL`
    becomes `AN`.
  - **W3** — every remaining `AL` becomes `R`. (Runs after W2 so the
    AL marker is still visible to the EN rewriter.)
  - **W4** — a single `ES` between two `EN`s collapses to `EN`. A
    single `CS` between two same-type numbers collapses to that
    type (`EN CS EN → EN EN EN` and `AN CS AN → AN AN AN`). Mixed-
    type CS (`EN CS AN`) and double separators (`EN ES ES EN`) do
    NOT collapse — W4 demands a *single* separator with a *same-type*
    number on each side.
  - **W5** — runs of `ET` adjacent to an `EN` on either side
    collapse to `EN`. ETs adjacent to `AN` (not `EN`) do not flip;
    isolated ET runs with no EN neighbour fall through to W6.
  - **W6** — every leftover `ES` / `ET` / `CS` becomes `ON`. This is
    the catch-all that drops separators which did not get absorbed
    into a number, so the N-rules see only `L` / `R` / `EN` / `AN` /
    `NSM` / `BN` / neutrals.
  - **W7** — `EN` whose most-recent strong type (`L` / `R` / `sos`)
    is `L` becomes `L`. After W3 the strong-type vocabulary is
    `{L, R, sos}` only — the spec example `L NI EN → L NI L` is
    asserted directly. `R` as the most-recent strong leaves the EN
    untouched.
- **`BidiClass::is_neutral_or_isolate()`** — predicate for the
  UAX #9 §3.3.5 / §3.3.6 NI alias (`B | S | WS | ON | FSI | LRI |
  RLI | PDI`). Surfaced now because W7's narration uses NI, and
  because every subsequent rule (N0..N2, I1..I2) dispatches on the
  same predicate.

Coverage: 14 unit tests in `src/bidi.rs` (every rule's positive +
negative spec examples plus a full-pipeline composition check) + 11
integration tests in `tests/round191_bidi_weak_types.rs` (the same
rule examples asserted through the `oxideav_scribe::resolve_weak_types`
public re-export). The realistic-pipeline test walks an
`AL NSM EN ET EN CS EN` sequence through every rule's footprint.

The `sos` / `eos` parameters keep the signature symmetric with the
forthcoming N-rules (which read both), even though W1..W7 actually
only read `sos` (via W1's start-of-sequence default, W2's
most-recent-strong implicit start, and W7's same). Callers without
X1..X10 wired up yet can pass `BidiClass::L` for paragraph level 0
and `BidiClass::R` for level 1 — that produces a correct W pass for
a single-paragraph no-isolate input.

Out of scope for this round (each is its own follow-up):

- **N0** bracket-pair-aware neutral resolution (needs
  `BidiBrackets.txt` from the UCD).
- **N1, N2** neutral type resolution against surrounding strong
  types + paragraph embedding direction.
- **I1, I2** implicit embedding level resolution.
- **X1..X10** explicit embedding / override / isolate stack
  machinery + the isolating-run-sequence partition + overflow
  counters.
- **L1..L4** line-level reordering + mirroring
  (`BidiMirroring.txt`).

Provenance: every rule transcribed verbatim from the dated snapshot
at `docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` §3.3.4 (UAX
#9 Revision 50, Unicode 16.0, fetched 2026-05-29). Every test input
comes directly from the spec's per-rule example blocks. No external
library source — HarfBuzz, ICU, FreeType, rustybuzz, the
`unicode-bidi` crate, etc. — was consulted at any point.

### Added — Unicode Bidirectional Algorithm foundation: UAX #9 character classes + P1/P2/P3 paragraph-level resolution (round 186)

First concrete UAX #9 (*Unicode Bidirectional Algorithm*) surface
landed on scribe. The crate had no BiDi at all before this round —
`layout` was advertised as "no bidi" and the `shaping::arabic`
module documented "logical-order input is assumed (post-bidi)" with
no helper to produce that ordering. Round 186 lands the **foundation**
surface every subsequent UBA rule (W / N / I / X / L) will dispatch
against:

- **`bidi::BidiClass`** — the 23 normative bidirectional character
  types from UAX #9 §3.2 Table 4 (3 Strong: `L` / `R` / `AL`; 7 Weak:
  `EN` / `ES` / `ET` / `AN` / `CS` / `NSM` / `BN`; 4 Neutral: `B` /
  `S` / `WS` / `ON`; 9 Explicit Formatting: `LRE` / `LRO` / `RLE` /
  `RLO` / `PDF` / `LRI` / `RLI` / `FSI` / `PDI`).
- **`bidi::bidi_class(c: char) -> BidiClass`** — `char` → class
  lookup. Coverage: the 12 explicit-formatting control characters
  (LRM, RLM, ALM, LRE, RLE, PDF, LRO, RLO, LRI, RLI, FSI, PDI)
  exhaustively; the paragraph / segment / line separators (LF / CR /
  NEL / U+2029 / TAB / VT / U+001F / FF / SPACE / U+1680 / U+2028 /
  U+2000..U+200A / U+202F / U+205F / U+3000); ASCII digits (EN),
  separators (`+ -` ES; `, . / :` CS; `# $ %` ET) and letters (L);
  C0 / DEL boundary-neutral controls; the Latin-1 supplement (NBSP =
  CS, currency / degree = ET, SOFT HYPHEN = BN, Latin-1 letters = L);
  the Combining Diacritical Marks (U+0300..U+036F = NSM); the Hebrew
  block (U+0590..U+05FF = R) and Hebrew Presentation Forms
  (U+FB1D..U+FB4F = R); the four core Arabic blocks (U+0600..U+06FF
  with `U+0660..U+0669` split out as AN, `U+06F0..U+06F9` as EN, and
  the documented Arabic NSM ranges separated out) and Syriac +
  Arabic Supplement + Arabic Presentation Forms A and B (all AL);
  Thaana (AL); N'Ko (R); ZWJ / ZWNJ / word-joiner family (BN); object
  replacement character U+FFFC (ON). Unmapped code points fall back
  to `L` per the UAX #9 §3.2 default ("Unassigned characters are
  given strong types in the algorithm.").
- **`bidi::paragraph_level(text: &str) -> u8`** — UAX #9 **P1 + P2
  + P3** in a single call. Walks the text, tracks isolate depth so
  the contents of any `LRI` / `RLI` / `FSI` ... `PDI` region are
  skipped (nested arbitrarily — overflow / overflow-isolate
  accounting from X5a..X5c is **not** implemented because P2 only
  needs to skip), finds the first strong character (L / R / AL),
  and returns 1 if it is R or AL, 0 otherwise. The default when no
  strong character is found is also 0. An unmatched `PDI` at top
  level is ignored (the spec achieves this by "skip until matching
  PDI or end of paragraph" but the top-level case is symmetric).
  Embedding initiators (`LRE` / `RLE` / `LRO` / `RLO` / `PDF`) are
  *not* skipped by P2, only isolates are — asserted by a dedicated
  test pair.
- **`bidi::split_paragraphs(text: &str) -> Vec<&str>`** — UAX #9
  **P1**. Splits at every type-`B` character and **keeps the
  separator with the preceding paragraph** (per the spec's wording
  "A paragraph separator (type B) is kept with the previous
  paragraph."). The returned slices concatenate back to the input
  byte-for-byte; two adjacent `B` characters yield an empty
  middle paragraph.
- **Predicates on `BidiClass`** — `is_strong()` (L / R / AL) and
  `is_isolate_initiator()` (LRI / RLI / FSI) for use by P2 + the
  forthcoming X-rules.

Coverage: 15 unit tests in `src/bidi.rs` (explicit-format set,
isolate-initiator + strong predicates, ASCII + Latin-1 + Hebrew +
Arabic + Combining Diacriticals class assignments, P1 split, P2
isolate-skip including nested initiators, P3 LTR/RTL defaults, P2
non-skip-of-embedding-initiators, unmatched-PDI tolerance) + 6
integration tests in `tests/round186_bidi_paragraph_level.rs` (the
same contracts asserted through the public re-export surface
`oxideav_scribe::{BidiClass, bidi_class, paragraph_level,
split_paragraphs}`).

Out of scope for this round (each is its own follow-up):

- **W1..W7** weak type resolution (NSM + EN/ES/CS + AN/ET joining
  rules).
- **N0..N2** neutral type resolution, including the §3.1.3 bracket
  pairs algorithm (`BidiBrackets.txt`).
- **I1..I2** implicit embedding level resolution.
- **X1..X10** explicit embedding / override / isolate stack
  machinery + the isolating-run-sequence partition + overflow
  counters.
- **L1..L4** line-level reordering + mirroring (`BidiMirroring.txt`).
- Filling out the per-code-point class table beyond the listed
  ranges — needs `DerivedBidiClass.txt` from the Unicode Character
  Database (UAX #9 references but does not include this file).

Provenance: every class assignment and every rule mirrors the
dated snapshot at
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` (UAX #9
Revision 50, Unicode 16.0, fetched 2026-05-29). No external
library source was consulted at any point.

### Added — Caller-driven Type-3 alternate-index selection (round 183)

A pair of new `Face` methods that let callers pick which
`AlternateSet` entry the GSUB Type-3 (Alternate Substitution) walker
applies per feature, instead of the round-156 hardcoded
`alternateIndex = 0`:

- **`Face::shape_text_with_alternates(text, feature_alternates)`** —
  auto-probe script-resolution variant. `feature_alternates` is a
  list of `(feature_tag, alternate_index)` pairs; the set of features
  applied is the union of the tags listed.
- **`Face::shape_text_with_script_and_alternates(text, script_tag,
  feature_alternates)`** — explicit-script variant. Mirrors the
  round-175 `shape_text_with_script` resolution semantics; every
  feature resolves against `script_tag` alone (no priority walk).

Contract:

1. **Index 0 reproduces the round-156 default** — the round-183
   surface is a strict superset, not a re-derivation. Asserted by
   `round183_index_zero_matches_round156_aalt_on_inter` /
   `_on_dejavu` against the existing fixtures.
2. **Out-of-range index falls back to cmap-identity per slot.**
   When `alternate_index` exceeds a covered glyph's `AlternateSet`
   entry count, `oxideav_ttf::Font::gsub_apply_lookup_type_3`
   returns `None` and we leave the slot's GID unchanged. Safe
   fallback for callers that don't pre-probe per-font alternate
   counts.
3. **Type-3 length-preservation is invariant across indices** —
   per OpenType §6.2.3, the run length matches `cmap_only.len()`
   regardless of which `alternate_index` the caller requests.
4. **Non-Type-3 features ignore the index.** Features that mix
   Type-3 with Type-1 (Single) / Type-2 (Multiple) / Type-4
   (Ligature) lookups still dispatch the non-Type-3 components
   with their existing walkers — `liga`'s Type-4 ligature collapse
   produces identical output whether the caller passes
   `(*b"liga", 0)` or `(*b"liga", u16::MAX)`.

Underlying mechanism: the new methods route through
`crate::shaping::shape_text_with_alternates_with_font` /
`shape_text_with_script_and_alternates_with_font`, which call the
existing private `shape_text_inner` with a per-call
`feature_alternates: &[(feature_tag, alternate_index)]` slice.
Inside the dispatch loop, the per-feature alternate index is
looked up via a linear scan (the list is short in practice) and
passed to `font.gsub_apply_lookup_type_3(lookup_idx, gid,
alt_index)` instead of the hardcoded `0`. Types 1, 2, and 4 are
dispatched unchanged.

Coverage: 7 new unit tests in `src/shaping/feature_subst.rs`
(empty-list contract, index-0-matches-156 contract, out-of-range
fallback, explicit-script unknown-tag contract, explicit-script
index-0 contract, non-Type-3 ignore-index contract, multi-sample
length-preservation matrix) + 13 new integration tests in
`tests/round183_alternate_index.rs` (the same contracts asserted
against the public `Face` surface, including a multi-feature mixed-
index walk).

### Added — Explicit-script-tag entry point + broadened script-tag probe list (round 175)

Two paired changes that broaden the caller-driven GSUB surface to
non-Latin scripts:

1. **`Face::shape_text_with_script(text, script_tag, features)`** —
   the deterministic-resolution mirror of `Face::shape_text`. Every
   requested feature tag is resolved against the explicit
   `script_tag` alone (with the script's DefaultLangSys), bypassing
   the script-tag priority walk. Useful when the caller already
   knows the script of the run — typically because the run came out
   of a script-segmenter or because the caller is shaping a
   known-language string — and the auto-probe walk's cross-script
   collision risk is unacceptable (e.g. `liga` published under both
   `latn` and `arab`). LookupType-1/2/3/4 dispatch semantics mirror
   `shape_text` exactly; lookup types 5/6/8 referenced by the
   requested features are silently skipped (same caller-driven
   contract as round 89/125/128/156).
2. **Broadened script-tag probe list in `shape_text`** — the
   underlying `resolve_feature_lookups` helper used by the
   auto-probing surface now walks `latn` → `cyrl` → `grek` → `DFLT`
   → `arab` → `hebr` → `thai` → `lao ` → Indic v1+v2 (`deva` /
   `dev2`, `beng` / `bng2`, `taml` / `tml2`, `gujr` / `gjr2`, `guru`
   / `gur2`, `knda` / `knd2`, `mlym` / `mlm2`, `orya` / `ory2`,
   `telu` / `tel2`, `sinh`) → `khmr` → `mymr` / `mym2` → `hang` /
   `hani` / `kana`. The round-15 four-tag prefix is preserved
   verbatim at the head of the list — every Latin / Cyrillic / Greek
   / DFLT resolution sees identical behaviour (no-regression
   guarantee, asserted by
   `round175_broadened_probe_preserves_latn_smcp_result`). Non-Latin
   tags resolve only when none of the round-15 four publishes the
   requested feature, which is the typical case for non-Latin runs.

The two together close a long-standing gap: until round 175, the
caller-driven `shape_text` API was limited to scripts that publish
the requested feature under one of `latn` / `cyrl` / `grek` /
`DFLT`. A font publishing `liga` only under `arab` (typical for
Arabic-only fonts) or a CJK font publishing `vert` under `hani` /
`kana` / `hang` was unreachable. Round 175 makes both paths work
without requiring callers to drop to `with_font` and call the raw
`oxideav-ttf` accessors.

A new export `shape_text_with_script_with_font` mirrors
`shape_text_with_font` at the function level for callers using
`Face::with_font` directly.

Tests:

- `src/shaping/feature_subst.rs` adds 6 in-module tests covering
  the probe-list invariants
  (`round175_probe_list_prefix_is_round15_priority`,
  `round175_probe_list_covers_broadened_scripts`), the explicit-
  script API contracts
  (`round175_explicit_unknown_script_is_cmap_identity`,
  `round175_explicit_empty_features_is_cmap_identity`,
  `round175_explicit_latn_matches_auto_probe_on_smcp`,
  `round175_explicit_dflt_unknown_feature_is_cmap_identity`), and
  the no-regression guarantee on the broadened auto-probe
  (`round175_broadened_probe_preserves_latn_smcp_result`).
- `tests/round175_shape_text_with_script.rs` adds 8 integration
  tests covering the public `Face::shape_text_with_script` surface
  (auto-probe agreement on `smcp` / `liga`, unknown-script
  cmap-identity, empty-text / empty-features baselines, `DFLT`
  resolution, caller-order preservation, and the cmap-baseline
  agreement with the auto-probe path).

Doc updates: README "Capabilities" gets a round-175 paragraph;
`lib.rs` re-exports `shape_text_with_script_with_font`;
`Face::shape_text` docstring is updated to describe the broadened
probe list.

### Added — GSUB LookupType 3 (Alternate Substitution) in `shape_text` (round 156)

`Face::shape_text` now dispatches GSUB LookupType 3 (Alternate
Substitution, Format 1) alongside the round-89 LookupType 1
(Single), round-125 LookupType 2 (Multiple), and round-128
LookupType 4 (Ligature) paths. For each covered slot the shaper
calls `oxideav-ttf::Font::gsub_apply_lookup_type_3(idx, gid, 0)`
to pick the first entry of the slot's `AlternateSet` and rewrites
the slot in place — Type 3 is length-preserving so the walker
mirrors the Type-1 single-substitution walker exactly.

The OpenType spec (§6.2.3 "Alternate Substitution Subtable")
defines exactly one format: Coverage on each input glyph plus a
per-coverage `AlternateSet` listing one or more
`alternateGlyphIDs[]`. The spec deliberately leaves "the
application of the OpenType Layout engine selects an alternate"
unpinned — we default to `alternateIndex = 0`, which is what the
`aalt` and `salt` features are designed to produce when consulted
without a user-specified pick. A higher-level surface that wanted
to expose user-driven indices would belong above this layer (the
existing `oxideav-ttf` accessor already takes `alternate_index`
per call).

The headline use case is `aalt` (Access All Alternates) — a
near-universal OpenType feature that publishes a Type-1 component
(single substitution into the designer-selected principal
alternate) plus a Type-3 component (the full per-glyph
`AlternateSet` for ad-hoc alternate access). Every test-fixture
font in `tests/fixtures/` ships an `aalt` feature with a Type-3
lookup; pre-round-156 the Type-3 component was silently skipped,
so a glyph covered *only* by the Type-3 lookup passed through
unchanged. Round 156 wires it into the caller-driven surface.

Tests: `tests/round156_alternate_subst.rs` adds 7 integration
tests covering both rich-coverage (Inter Variable, 37 Type-3 hits
across ASCII probes) and sparse-coverage (DejaVu Sans, 5 hits at
'I', 'J', 'a', 'l', 'y') fonts:

- `inter_aalt_substitutes_via_lookup_type_3` — the headline
  contract: `shape_text("a", &[aalt])` reshapes via the Type-3
  alternate-0 (different gid from `cmap('a')`, length 1) where
  previously the Type-3 lookup was silently skipped.
- `inter_aalt_reshapes_many_lowercase_slots` — bulk-coverage
  check: at least 5 of 7 lowercase ASCII letters reshape via the
  Type-3 lookup.
- `dejavu_aalt_is_pure_type_3` — `aalt` on DejaVu is a single
  Type-3 lookup; round-156 reshapes 'I' / 'a' / 'l' / 'y' /
  duplicates in `"Iaaly"`.
- `dejavu_aalt_outside_coverage_is_cmap_identity` — uncovered
  glyphs ('b' / 'c' / 'd' / 'e' / 'f' / 'g' on DejaVu) pass through
  unchanged.
- `aalt_is_idempotent_on_inter` — coverage is on the input glyphs,
  not the substitutes, so re-applying `aalt` is a no-op.
- `aalt_does_not_affect_run_length` — Type 3 is length-preserving
  across both fixtures and several input compositions.
- `font_without_aalt_is_cmap_identity` — unknown feature tag
  (`zzzz`) doesn't accidentally pull in a Type-3 lookup.

Plus two unit tests in `src/shaping/feature_subst.rs`
(`aalt_dispatches_lookup_type_3_on_inter`,
`aalt_is_idempotent_on_dejavu`) mirroring the existing per-module
test convention.

Lookups of the remaining declared types (5 / 6 / 8) referenced by
the requested features are still silently skipped on the
caller-driven surface — contextual / chained-contextual /
reverse-chained substitutions continue to flow through
`Shaper::shape` / `FaceChain::shape` via `shaping::general`.

### Added — GSUB LookupType 4 (Ligature Substitution) in `shape_text` (round 128)

`Face::shape_text` now dispatches GSUB LookupType 4 (Ligature
Substitution, Format 1) alongside the round-89 LookupType 1
(Single Substitution) and round-125 LookupType 2 (Multiple
Substitution) paths. The shaper walks the cmap'd run
left-to-right; at each cursor position it asks
`oxideav-ttf::Font::gsub_apply_lookup_type_4(idx, &gids[pos..])`
whether the lookup matches a prefix starting at the cursor.
On a hit the `consumed` glyphs `gids[pos..pos+consumed]` are
spliced to the single replacement glyph and the cursor advances
by 1 (past the new ligature). The advance-by-1 is what
`Shaper::shape`'s round-1 ligature pass already does and is
the natural mirror of the round-125 Type-2 walker.

The canonical use case is `liga` / `dlig` / `rlig` collapsing
multi-glyph component sequences into a single ligature glyph
(e.g. fi / fl / ffi / ffl on DejaVu Sans, or the historic
ct / st discretionary ligatures on serif text fonts). The
`Shaper::shape` / `FaceChain::shape` pipeline already collapsed
ligatures via the round-1 `lookup_ligature` walker; round 128
brings the same capability to the caller-driven
`shape_text(text, features)` surface so explicit per-call feature
lists can now express ligature substitution as well.

Tests: `tests/round128_ligature_subst.rs` adds 17 new
integration tests around a per-byte synthetic TTF (no external
library consulted; every byte layout follows the Microsoft
Typography OpenType spec — chapter 6 §6.2.4 LigatureSubstFormat1
plus the common-table Coverage Format 1 layout, transcribed
from the published spec):

- A parameterised builder that produces a 5-glyph TTF
  (`.notdef` + up to 4 letters + ligature glyphs) with a
  Format-12 cmap and a GSUB table publishing one `liga` feature
  under script `DFLT` with one LigatureSubstFormat1 lookup
  populated from a caller-supplied `LigatureSet` table.
- `synthetic_font_cmap_routes_a_b_c`,
  `synthetic_font_publishes_liga_under_dflt`, and
  `synthetic_font_has_one_lookup_type_4` lock the parsed shape
  of the synthetic font (cmap mapping + feature publication +
  GSUB lookup count / type).
- `liga_collapses_two_components_into_ligature` is the headline
  contract: shape_text("ab", [liga]) returns the single
  replacement glyph instead of the cmap'd [1, 2].
- `liga_is_noop_on_uncovered_prefix` /
  `liga_is_noop_when_tail_doesnt_match` cover the two miss
  paths (first-component-not-in-coverage and
  first-matches-but-tail-doesn't).
- `liga_mixed_input_collapses_only_matching_prefix` verifies
  multiple ligature matches in a single run.
- `liga_partial_then_match` walks past an uncovered glyph and
  fires the ligature at the next position.
- `liga_does_not_re_match_its_own_output` is the idempotence
  guard.
- `liga_empty_text_yields_empty_run`,
  `liga_empty_features_is_cmap_identity_on_ab`, and
  `unknown_feature_skips_type_4_lookup` are the empty-input and
  unknown-feature baselines.
- `liga_longest_match_first_picks_3_glyph_ligature` /
  `liga_longest_match_first_falls_back_when_tail_missing` cover
  the spec-mandated longest-match-first ordering within a single
  LigatureSet (a 3-glyph ligature with the same first component
  must win over a 2-glyph one when the trailing components are
  present, and fall back to the 2-glyph one when they aren't).
- `liga_two_sets_each_fires_independently` /
  `liga_two_sets_first_set_only_on_partial_input` cover
  multiple LigatureSets routed by coverage (different first
  components, each with their own ligature record).
- `liga_single_component_record_behaves_like_single_subst`
  covers the spec-legal-but-rare `componentCount = 1` edge case
  (effectively a Single Substitution dressed as a ligature).

Plus three new in-module tests in
`src/shaping/feature_subst.rs` (existing 9 → 11) replacing the
pre-128 `liga_is_skipped_because_it_is_lookup_type_4` test with
three new tests against real DejaVu Sans:
`liga_collapses_fi_via_lookup_type_4` (fi → single ligature
glyph), `liga_leaves_uncovered_glyphs_alone` (mixed "abfi" → 3
glyphs not 4), and `liga_is_identity_on_uncovered_run` ("abc"
unchanged because no f/l/i prefix matches).

The pre-existing `tests/round89_single_subst.rs ::
dejavu_liga_is_skipped_because_lookup_type_is_4` test was
renamed to `dejavu_liga_is_now_dispatched_as_lookup_type_4`
and its assertions flipped to lock the new round-128 contract
(fi cmap'd to 2 glyphs, liga collapses to 1 different glyph).

Lookups of any other declared type (Alternate = 3, Context = 5,
ChainContext = 6, ReverseChainContext = 8) referenced by the
requested features remain silently skipped on the `shape_text`
surface; the broader `apply_one_lookup` walker in
`shaping::general` continues to dispatch all declared types end-
to-end through the always-on `ccmp` / `calt` passes.

Clean-room note: OpenType §6.2.4 LigatureSubstFormat1 byte
layout is implemented inside `oxideav-ttf` (already shipped; no
scribe-side decode work this round); scribe's round-128 layer
is a thin dispatcher plus a per-byte synthetic-fixture builder
transcribed from the published OpenType spec. No HarfBuzz /
FreeType / Pango / Skia source was consulted; no WebSearch /
WebFetch was invoked during this round.

### Added — GSUB LookupType 2 (Multiple Substitution) in `shape_text` (round 125)

`Face::shape_text` now dispatches GSUB LookupType 2 (Multiple
Substitution, Format 1) alongside the round-89 LookupType 1
(Single Substitution) path. The shaper walks the cmap'd run
left-to-right; when a Type-2 lookup's coverage matches a slot,
the single input glyph is spliced out and replaced by the
`Sequence` record's `glyphCount` substituteGlyphIDs, and the
cursor advances past the inserted run so the same lookup
doesn't re-match its own output. The OpenType spec (§6.2.2)
explicitly permits `glyphCount = 0` as a deletion form; the
returned `Vec<u16>` reflects the post-substitution length,
which may be 0, shorter than, equal to, or longer than the
input.

The canonical use case is `ccmp` "split a precomposed glyph
into base + combining mark" so a subsequent GPOS mark-
attachment pass can position the mark independently. The
`shaping::general` `ccmp` / `calt` pipeline already dispatched
Type 2 since round 15; round 125 brings the same capability
to the caller-driven `shape_text(text, features)` surface so
explicit per-call feature lists (`smcp`, `c2sc`, `frac`,
`salt`, `ss01..ss20`, `cv01..cv99`, etc.) can now express
multiple-substitution lookups as well.

Tests: `tests/round125_multi_subst.rs` adds 11 new integration
tests around a per-byte synthetic TTF (no external library
consulted; every byte layout follows the Microsoft Typography
OpenType spec):

- A minimal 4-glyph TTF (`.notdef` + 'a' + 'b' + 'c') with a
  Format-4 cmap mapping 'a'/'b'/'c' to GIDs 1/2/3 and a GSUB
  table publishing one `ccmp` feature under script `DFLT`
  with one MultipleSubstFormat1 lookup. The lookup's
  coverage and Sequence record are parameterised, so the
  same builder produces both the split-variant (gid 1 →
  [2, 3]) and the deletion-variant (gid 1 → []).
- `synthetic_font_cmap_routes_a_b_c`,
  `synthetic_font_publishes_ccmp_under_dflt`, and
  `synthetic_font_has_one_lookup_type_2` lock the parsed shape
  of the synthetic font (cmap mapping + feature publication +
  GSUB lookup count / type).
- `ccmp_splits_a_into_b_c_via_lookup_type_2` is the headline
  contract: shape_text("a", [ccmp]) returns [2, 3] instead of
  the cmap [1].
- `ccmp_is_noop_on_uncovered_glyph` asserts coverage gating
  (gid 2 isn't in the lookup's coverage; shaping "b" is
  identity).
- `ccmp_mixed_input_expands_only_covered_slot` verifies "ab"
  expands the 'a' slot and leaves 'b' intact → output is
  `[2, 3, 2]`, length 3.
- `ccmp_walker_does_not_re_match_its_own_output` /
  `ccmp_lookup_type_2_glyph_count_zero_deletes_input` cover
  the walker's advance-past-substitution contract and the
  spec-legal `glyphCount = 0` deletion form.
- `ccmp_empty_text_yields_empty_run`,
  `ccmp_empty_features_is_cmap_identity_on_a`, and
  `unknown_feature_skips_type_2_lookup` are the empty-input
  and unknown-feature baselines.

Plus three new in-module tests in
`src/shaping/feature_subst.rs` (existing 9 → 12) updating the
`liga`-is-skipped contract docstring to reflect the
LookupType-1/2 surface (LookupType 4 ligature work still
flows through `Shaper::shape` / `FaceChain::shape`).

Lookups of any other declared type (Alternate = 3, Ligature
= 4, Context = 5, ChainContext = 6, ReverseChainContext = 8)
referenced by the requested features remain silently skipped
on the `shape_text` surface; the broader `apply_one_lookup`
walker in `shaping::general` continues to dispatch all
declared types.

Clean-room note: OpenType §6.2.2 MultipleSubstFormat1 byte
layout is implemented inside `oxideav-ttf` (already shipped;
no scribe-side decode work this round); scribe's round-125
layer is a thin dispatcher plus a per-byte synthetic-fixture
builder transcribed from the published OpenType spec. No
HarfBuzz / FreeType / Pango / Skia source was consulted; no
WebSearch / WebFetch was invoked during this round.

### Added — caller-driven GSUB LookupType 1 application (round 89)

A new public surface — `Face::shape_text(text, features) -> Vec<u16>` —
cmap's the input text and applies every **GSUB LookupType 1 (Single
Substitution)** lookup the requested feature tags reference under
`latn` / `cyrl` / `grek` / `DFLT`. Format 1 (delta) and Format 2
(substitute-array) sub-tables per OpenType §6.2.1 are both
dispatched through `oxideav_ttf::Font::gsub_apply_lookup_type_1`;
LookupType-7 ExtensionSubst wrappers around a Type-1 lookup are
unwrapped transparently.

Round-89 scope is single-substitution only. Lookups of other
declared types (Multiple, Alternate, Ligature, Contextual,
ChainContext, ReverseChainContext) referenced by the requested
features are silently skipped — ligature collapsing and contextual
rules remain on the existing `Shaper::shape` / `FaceChain::shape`
pipeline.

Typical feature tags this surface unlocks (none of which the
always-on round-15 `ccmp` / `calt` passes touch):

- `smcp` / `c2sc` — small caps (from lower / from upper).
- `case` — case-sensitive forms.
- `salt` / `ss01..ss20` / `cv01..cv99` — stylistic alternates,
  sets, and per-character variants.
- `sups` / `subs` / `numr` / `dnom` / `ordn` — vertical /
  role-based number forms.
- `frac` — fractions (the Type-1 digit reshape component only;
  the contextual `1/2` collapse rule is a Type-4/5 lookup and
  remains a TODO for a later round).
- `zero` — slashed zero.
- `pnum` / `tnum` — proportional / tabular numerals.

Round-89 test coverage adds 20 new tests (9 in
`src/shaping/feature_subst.rs`, 11 in
`tests/round89_single_subst.rs`):

- Empty-text and empty-features baselines (cmap identity).
- Inter Variable `smcp` reshapes lowercase ASCII (`"Hi"` →
  `[H_gid, smcp(i_gid)]` — upper-case stays unchanged because it's
  outside `smcp` coverage; lowercase reshapes to small-cap variant).
- Inter `sups` reshapes most digit slots; `subs` is independent
  from `sups`.
- Inter `salt` is well-defined on lowercase.
- Caller-ordered features: `[*b"smcp", *b"case"]` on lowercase
  matches `[*b"smcp"]` alone (case is a no-op for letters);
  `[*b"smcp", *b"smcp"]` is idempotent (re-applying smcp doesn't
  match the post-substitution glyphs).
- DejaVu Sans's `liga` (LookupType 4) is the documented no-op —
  proves the Type-1-only contract.
- Unknown feature tag (`zzzz`) and font without the requested
  feature (DejaVu's missing `smcp`) both pass through unchanged.

Clean-room note: OpenType §6.2.1 Format 1/2 byte layouts are
implemented inside `oxideav-ttf` (which has its own clean-room
provenance); scribe's round-89 layer is a thin dispatcher and does
not re-derive the table format itself. No HarfBuzz / FreeType /
Pango / Skia source was consulted; no WebSearch / WebFetch was
invoked during this round.

### Added — GSUB feature-tag introspection (round 88)

Two new accessors on `Face` surface the OpenType feature-tag set the
underlying GSUB table publishes:

- `Face::gsub_features_for_script(script_tag, lang_tag)` → `Vec<[u8; 4]>` —
  returns the four-byte feature tags published under a script (in
  declaration order, required-feature first per the underlying
  `oxideav-ttf` contract).
- `Face::has_gsub_feature(script_tag, feature_tag)` → `bool` —
  convenience predicate for callers that just need to gate on
  feature presence.

Both are pure pass-through accessors over
`oxideav_ttf::Font::gsub_features_for_script`; semantics live in
`oxideav-ttf`. Returns an empty vec / `false` for OTF faces, fonts
without a GSUB table, and unknown / absent script tags.

Round-88 test coverage adds 10 new tests in
`tests/round88_gsub_features.rs`:

- Introspection: unknown-script / unknown-feature empty cases.
- Introspection: DejaVu Sans `latn` publishes `ccmp` and `liga`;
  every tag is printable ASCII.
- Introspection: Inter Variable `latn` snapshots the full tag set
  (38 tags including `aalt` / `c2sc` / `calt` / `case` / `ccmp` /
  `cv01..cv13` / `dlig` / `dnom` / `frac` / `numr` / `ordn` / `pnum` /
  `salt` / `sinf` / `smcp` / `ss01..ss08` / `subs` / `sups` / `tnum` /
  `zero`). Documents Inter's deliberate omission of `liga` (lives in
  `dlig`/`calt`) and `kern` (GPOS-only — a future GPOS introspection
  accessor is needed).
- Round-15 pipeline on a second font: Inter Variable's `ccmp` lookup
  substitutes the dotless-i variant before a combining-above mark, and
  a 56-char ASCII pangram is byte-identical to the cmap-only output
  (no calt false-positives).

### Added — general-script `ccmp` + `calt` (round 15)

Wires the OpenType **required-feature** `ccmp` (Glyph Composition /
Decomposition) as a pre-ligature pass and `calt` (Contextual
Alternates) as a post-ligature pass into the post-cmap path of
`shape_run_with_font`. Both passes resolve features through the new
`shaping::general` module, which probes the script-tag list `latn` /
`cyrl` / `grek` / `DFLT` in priority order and dispatches every lookup
under the chosen feature according to its declared GSUB LookupType:

- LookupType 1 (single substitution) — already used by Indic.
- **LookupType 2 (multiple substitution)** — now reachable for the
  first time. The canonical decomposition site: `ç → c + combining
  cedilla`, etc.
- LookupType 3 (alternate substitution) — picks the spec-default
  alternate index 0 (user-driven indices belong on a higher API).
- LookupType 4 (ligature substitution) — feature-tag-aware variant of
  the existing untargeted walker.
- LookupType 5 / 6 (contextual / chained context) — already used by
  Indic; now reachable for Latin too. Fonts use type-6 chained context
  to make `ccmp` rules condition on whether a following mark is
  present (e.g. DejaVu Sans rewrites `i → dotless-i` only before a
  combining-above mark).
- LookupType 8 (reverse chained context) — single-position dispatch.

**Measured delta against DejaVu Sans:**

- `chain.shape("i\u{0307}")` previously produced `[gid_i, gid_dot]`
  (visually wrong — dot of "i" collides with combining dot). Now
  produces `[gid_dotless_i, gid_dot]`, matching the font's published
  ccmp rule.
- `chain.shape("I\u{0307}")` previously produced
  `[gid_I, gid_dot_default]`; now produces
  `[gid_I, gid_dot_capital_variant]`, matching the case-specific
  ccmp lookup.
- ASCII-only runs (`"Hello, world!"`) are bit-identical to round-14
  output — the coverage tables ensure the new pass is a no-op for any
  glyph not in the `ccmp` / `calt` coverage.

Four new integration tests (`tests/round15_ccmp_calt.rs`) lock the
positive cases AND the negative-control (`"a\u{0301}"` is a pass-through
because DejaVu Sans publishes no rule for that pair). Total test count:
lib 268→270, integration 64→68.

No external library source was consulted. The feature-application
ordering follows the spec's "required features first" rule + the
public OpenType registry's documented feature semantics for `ccmp` /
`calt`; the round-15 lookup-dispatch code is built from `oxideav-ttf`'s
public per-type entry points and the lookup-type metadata returned by
`Font::gsub_lookup_list`.

### Changed — hygiene (round 75)

Internal-only hygiene round. No new spec material consulted; the
shaper's behavioural surface is unchanged.

- `Error::source()` is now wired so callers walking the source chain
  (anyhow, thiserror's `#[from]` walker, the `?` operator with
  `dyn Error` conversion) see the underlying `oxideav_ttf::Error` /
  `oxideav_otf::Error` rather than just the wrapper. Previously the
  `From` impls preserved the inner error but the `source()` method
  returned `None`.
- Crate-level `lib.rs` doc-comment is brought current with rounds
  13 (Burmese + Lao + multi-glyph context-aware GSUB) and 14
  (`Face::mvar` / `hvar` / `vvar` / `stat` / `cff2` / `name_id`),
  matching the README's already-updated capabilities tour. Same
  text — the README was already in sync; the lib doc had drifted.
- The two `Shaper::with_variation_coords` doctest snippets are
  converted from `ignore` to `no_run`. They now compile-check
  against the public API (catching any future signature drift) but
  still skip execution because both need a non-trivial `Face`
  instance to be meaningful.
- Added a small `error_tests` module covering the `Error` /
  `Display` / `From` surface (4 new lib tests; total 264 → 268).
  Round-trips `Face::from_ttf_bytes` / `from_otf_bytes` with 4-byte
  garbage to confirm the wrapper variants carry the inner parser
  error.

### Added — variable-font metrics + style attributes (round 14, #454)

Round 14 closes the variable-font metrics gap that the round-9 outline
work left open. The four metric-variation tables now have first-class
parsers + per-coord lookup methods on `Face`:

- **MVAR** (Metrics Variations) — `Face::mvar()` parses the table;
  `Face::metric_delta(b"hasc")` returns the ascender delta in font
  units at the current variation coords (similar accessors via tag
  for `cpht` cap-height, `xhgt` x-height, `undo` underline offset,
  `unds` underline size, `strs` strikeout size, `stro` strikeout
  offset, etc. — every tag in the OpenType MVAR ValueTag registry).
- **HVAR** (Horizontal-Advance Variations) — `Face::hvar()` parses
  the table; `Face::h_advance_delta(gid)` returns the per-glyph
  advance-width delta. The implicit `glyphID → (0, glyphID)`
  identity (used by HVAR tables that omit the optional
  advanceWidthMapping) is handled transparently.
- **VVAR** (Vertical-Advance Variations) — `Face::vvar()` /
  `v_advance_delta(gid)` mirrors HVAR for vertical layout. Returns
  `None` / `0.0` for the horizontal-only fonts that omit VVAR
  (the common case for Latin fonts).
- **STAT** (Style Attributes) — `Face::stat()` parses the table;
  `stat_axes()` enumerates the design axes (each carries a `name`-
  table id for the axis label); `stat_axis_values()` enumerates
  every axis-value record across all four spec formats:
  `Single` (one named point on one axis — e.g. `wght=400 →
  "Regular"`), `Range` (e.g. `wght 600..700 → "SemiBold/Bold"`),
  `Linked` (named value plus a "linked" value used for the
  bold/italic toggle), and `Combined` (multi-axis named
  combinations — e.g. `wght=700 + wdth=75 → "Bold Condensed"`).

The four metric tables share two pieces of plumbing:

- **`ItemVariationStore`** — the OpenType-spec delta-storage
  primitive. One ItemVariationStore can hold multiple sub-tables;
  each sub-table publishes a region-index list, a delta-set count,
  and a packed delta array. `resolve_delta(outer, inner, &coords)`
  walks the regions, computes the per-region scalar via the
  spec's "(coord - start) / (peak - start)" ramp + sign / zero
  rules, and accumulates the scaled delta sum.
- **`DeltaSetIndexMap`** — short (format 0) + long (format 1)
  variants both supported. Resolves an item key (glyph id for
  HVAR/VVAR, or an implicit 0 for MVAR's per-tag lookup) into
  an `(outer_index, inner_index)` pair that addresses the IVS.

`Face::name_id(nid)` resolves any `name`-table id to the
highest-ranked Unicode string, with the same priority the
underlying TTF parser uses (Windows English first, Mac Roman
English second, anything Unicode-y after, then any remaining
record). Closes the surface for callers that consumed an
`axis_name_id` / `subfamily_name_id` (from `fvar`) or a
`value_name_id` (from STAT) and need the human-readable label —
they no longer have to reach into `Face::with_font` for it.

`Face::cff2()` parses the CFF2 INDEX walker (header + Top DICT
+ Global Subrs + CharStrings INDEX) and reports the table's
glyph count + variation-axis count + `has_charstrings` boolean.
Full Type 2 v3 charstring evaluation under variations (with the
`blend` operator) is the deferred follow-up; once the underlying
`oxideav-otf` crate exposes a CFF2 charstring interpreter,
scribe will lift it onto `Face::glyph_path` for OTF / CFF2
variable fonts the same way it does for TT / gvar today.

All variation tables are parsed locally in scribe (`crate::variations`)
from raw font bytes obtained via `Face::raw_bytes()` rather than from
new APIs on `oxideav-ttf` / `oxideav-otf` — keeps the round
self-contained without coordination on the producer crates' release
cadence.

Test coverage:
- `crate::variations::tests` — 5 new unit tests (synthetic-bytes
  coverage of `ItemVariationStore`, `DeltaSetIndexMap`, `StatTable`
  format-1 round-trip, `NameTableSnapshot` UTF-16 decode, `CFF2`
  INDEX walker on empty + non-empty INDEX bytes).
- `tests/round14_variable_metrics.rs` — 16 new integration tests
  against `tests/fixtures/InterVariable.ttf` (Inter ships MVAR +
  HVAR + STAT with two `fvar` axes — `wght` 100..900 + `opsz`
  14..32 — plus 9 named instances). MVAR enumerates well-known
  metric tags and produces a non-zero delta at `wght=900`. HVAR
  produces a non-zero per-glyph advance delta at `wght=900`.
  VVAR is correctly absent (Inter is horizontal-only). STAT
  enumerates ≥ 2 design axes (`wght` + `opsz`), with at least
  one Single-format record on the wght axis. `name_id` resolves
  the family name, every `axis_name_id`, and at least one named-
  instance subfamily label. CFF2 is correctly absent (Inter is
  TT-flavoured). Plus 2 OTF-flavour tests against
  `tests/fixtures/SourceSans3-Regular.otf` confirming the
  `name_id` resolver works on OTF magic and that a static OTF
  font reports `mvar / hvar / vvar / stat / cff2 == None`.

The implementations are clean-room readings of:

- Microsoft OpenType §"MVAR — Metrics Variations Table".
- Microsoft OpenType §"HVAR — Horizontal Metrics Variations Table".
- Microsoft OpenType §"VVAR — Vertical Metrics Variations Table".
- Microsoft OpenType §"STAT — Style Attributes Table".
- Microsoft OpenType §"Item Variation Store Header and Item Variation
  Subtables".
- Microsoft OpenType §"Delta Set Index Map Table".
- Microsoft OpenType §"name — Naming Table".
- Adobe Technical Note #5176 §"CFF2 charstring format" and TN5177.

No HarfBuzz / FreeType / fontTools / pango source consulted.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).