### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.8...v0.1.9) - 2026-06-01
+
+### Other
+
+- UAX #9 implicit-level resolution rules I1 + I2 (round 204)
+
 ### Added — UAX #9 §3.3.6 implicit-level resolution rules I1 + I2 (round 204)
 
 Fourth concrete UAX #9 surface on scribe, layered directly on top

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — UAX #9 §3.3.6 implicit-level resolution rules I1 + I2 (round 204)
+
+Fourth concrete UAX #9 surface on scribe, layered directly on top
+of the round 198 neutral-type pass: the §3.3.6 implicit-level
+resolution rules I1 and I2. The phase consumes the resolved
+bidirectional types (the post-W, post-N output containing only
+`L` / `R` / `EN` / `AN` / `NSM` / `BN`) plus the run's base
+embedding level and emits one **embedding level per character**,
+which is the precondition the future §3.4 L-rules (line-level
+reordering) consume.
+
+- **`bidi::resolve_implicit_levels(classes: &[BidiClass],
+  embedding_level: u8) -> Vec<u8>`** — applies Table 5 row-by-row:
+  - At an **even (LTR)** base level: `L` stays, `R` climbs by 1,
+    `AN` / `EN` climb by 2 (I1).
+  - At an **odd (RTL)** base level: `R` stays, `L` / `EN` / `AN`
+    climb by 1 (I2).
+  - `BN` is ignored per the §5.3 HL3 conformance clause ("In rules
+    I1 and I2, ignore BN.") — it keeps the embedding level rather
+    than being promoted. Any W1-leftover `NSM` from the boundary
+    case where the sequence opens with an `NSM` is treated the
+    same.
+- **`oxideav_scribe::resolve_implicit_levels`** + the matching
+  `oxideav_scribe::bidi::resolve_implicit_levels` — public re-
+  exports alongside `resolve_weak_types` and `resolve_neutral_types`.
+
+After the pass the per-character levels satisfy the §3.3.6
+narrative guarantees:
+
+1. RTL text always ends up at an **odd** level.
+2. LTR + numeric text always ends up at an **even** level.
+3. Numeric text always ends up at a level **strictly higher** than
+   the paragraph level.
+
+**27 new tests** (11 unit + 16 integration via
+`tests/round204_bidi_implicit_levels.rs`): every Table-5 row at
+both even and odd base levels, higher nested override levels (e.g.
+`embedding_level=2` and `=3`), the BN-ignored case at both
+parities, W1-leftover NSM treatment at the head of a sequence, the
+three narrative guarantees enforced across a range of paragraph
+levels, and two realistic compose-with-W-and-N pipelines: an LTR
+paragraph `[L, EN, ON, R]` walking through W7's EN-after-L → L,
+N2's L/R-mismatch ON → L embedding-direction fallback, and I1's
+R → 1 promotion; and the round-191 RTL Arabic-phone-style
+`[AL, NSM, EN, ET, EN, CS, AN]` sequence walking through all of
+W1..W7, then N1's AN/AN-as-R collapse of the lone ON, then I2's
+AN → +1 promotion.
+
+**X / L rules remain deferred**; N0 (bracket-pair resolution) is
+still blocked on the Unicode `BidiBrackets.txt` data file not
+being vendored under `docs/`.
+
+Provenance: rules transcribed verbatim from
+`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` §3.3.6
+(UAX #9 Revision 50, Unicode 16.0) plus the §5.3 HL3
+conformance clause. No external library source consulted — no
+ICU / HarfBuzz / FriBidi / minikin / `unicode-bidi` crate /
+upstream reference engine reached at any point.
+
 ### Added — UAX #9 §3.3.5 neutral-type resolution rules N1 + N2 (round 198)
 
 Third concrete UAX #9 surface on scribe, layered on top of the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-scribe"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -314,6 +314,29 @@ let rgba: oxideav_core::VideoFrame = Renderer::new(400, 80).render(&frame);
   full Arabic phone-number-style pipeline. `BidiClass::is_neutral_or_isolate()`
   exposes the §3.3.5 NI alias predicate for the upcoming N-rules.
   N / I / X / L rules remain deferred.
+- **BiDi implicit-level resolution I1 + I2 (round 204)** —
+  `bidi::resolve_implicit_levels(&[BidiClass], embedding_level: u8) ->
+  Vec<u8>` runs the UAX #9 §3.3.6 implicit-level pass over a slice
+  of resolved bidirectional types (the post-W, post-N output) and
+  emits one embedding level per character per Table 5: at an even
+  (LTR) base level, `R` climbs `+1` and `AN` / `EN` climb `+2`; at
+  an odd (RTL) base level, `L` / `EN` / `AN` climb `+1`. The
+  spec's §5.3 HL3 conformance clause ("In rules I1 and I2, ignore
+  BN.") is honoured — `BN` keeps the embedding level rather than
+  being promoted; W1-leftover `NSM`s from the boundary case are
+  treated the same. After the pass RTL text always sits at an odd
+  level, LTR + numeric text at an even level, and numeric text is
+  strictly higher than the paragraph level — exactly the
+  precondition the §3.4 L-rules consume. 11 unit + 16 integration
+  tests cover every Table-5 row at both even and odd base levels,
+  higher nested override levels, BN ignore at both parities,
+  W1-leftover NSM treatment, the §3.3.6 narrative guarantees (RTL
+  always odd, LTR/numeric always even, numbers strictly above the
+  paragraph level), and two compose-with-W-and-N realistic
+  pipelines (an LTR `[L, EN, ON, R]` and the round-191 RTL Arabic-
+  phone `[AL, NSM, EN, ET, EN, CS, AN]` sequence). X / L rules
+  remain deferred; N0 (bracket-pair resolution) is still blocked
+  on `BidiBrackets.txt` vendoring.
 - **BiDi neutral-type resolution N1 + N2 (round 198)** —
   `bidi::resolve_neutral_types(&mut classes, embedding_level, sos, eos)`
   runs the UAX #9 §3.3.5 neutral / isolate-formatting pass over one
@@ -354,7 +377,8 @@ let rgba: oxideav_core::VideoFrame = Renderer::new(400, 80).render(&frame);
 - **Pixel work** — bitmap rasterisation, alpha compositing, synthetic
   bold dilation, stroke dilation. All in
   [`oxideav-raster`](https://github.com/OxideAV/oxideav-raster).
-- **Bidi (UAX #9) W / N / I / X / L rules**, **CFF2 variable charstrings**
+- **Bidi (UAX #9) X / L rules** (the implicit-level pass I1 + I2 landed
+  in round 204; W1..W7 in round 191; N1 + N2 in round 198), **CFF2 variable charstrings**
   (the `blend` operator in TN5177 v3 — scribe parses the CFF2
   INDEX walker, but doesn't yet emit variation-blended cubic
   outlines), **TrueType bytecode hinting**, **subpixel LCD

--- a/src/bidi.rs
+++ b/src/bidi.rs
@@ -1,7 +1,8 @@
 //! Unicode Bidirectional Algorithm — UAX #9 character classes,
 //! paragraph-level resolution (rules P1 / P2 / P3), weak-type
-//! resolution (rules W1..W7), and neutral-type resolution (rules N1
-//! and N2 — bracket-pair rule N0 deferred to a follow-up round).
+//! resolution (rules W1..W7), neutral-type resolution (rules N1
+//! and N2 — bracket-pair rule N0 deferred to a follow-up round),
+//! and implicit-level resolution (rules I1 + I2 from §3.3.6).
 //!
 //! ## Scope
 //!
@@ -59,6 +60,18 @@
 //!   call the slice contains no NI: every former neutral or isolate
 //!   formatting character has been resolved to a strong direction,
 //!   ready for the §3.3.6 implicit-level pass (I1 / I2).
+//! - [`resolve_implicit_levels`] — the **I1 + I2** rules from
+//!   §3.3.6 applied to a slice of resolved types together with a
+//!   base embedding level. Produces a `Vec<u8>` of per-character
+//!   embedding levels per Table 5: at an even (LTR) base level,
+//!   `R` climbs by 1 and `AN`/`EN` climb by 2; at an odd (RTL) base
+//!   level, `L`/`EN`/`AN` climb by 1. `BN` is ignored per §5.3
+//!   HL3 ("In rules I1 and I2, ignore BN.") — it stays at the
+//!   embedding level; any W1-leftover `NSM` from the boundary case
+//!   is treated the same. After this phase RTL text always sits at
+//!   an odd level, LTR + numeric text at an even level, and
+//!   numeric text is strictly higher than the paragraph level —
+//!   exactly the precondition the L-rules consume.
 //!
 //! ## Out of scope (deferred to follow-up rounds)
 //!
@@ -66,7 +79,6 @@
 //!   Unicode `BidiBrackets.txt` data file to identify opening /
 //!   closing paired brackets, which is not yet vendored under
 //!   `docs/`.
-//! - I1..I2 (implicit embedding level resolution).
 //! - X1..X10 (explicit embedding / override / isolate stack
 //!   machinery + the isolating-run-sequence partition).
 //! - L1..L4 (line-level reordering + mirroring).
@@ -862,6 +874,145 @@ pub fn resolve_neutral_types(
             *cls = target;
         }
     }
+}
+
+/// Resolve **implicit embedding levels** per UAX #9 §3.3.6 (rules
+/// **I1** + **I2**).
+///
+/// This is the last per-character phase of the BiDi algorithm before
+/// line-level reordering (`L1`..`L4`): it adjusts the embedding level
+/// of every character based on its resolved bidirectional type so
+/// that right-to-left text always ends up at an odd level, left-to-
+/// right and numeric text always ends up at an even level, and
+/// numeric text always ends up at a level higher than the paragraph
+/// level. The spec rules verbatim:
+///
+/// > **I1.** For all characters with an even (left-to-right)
+/// > embedding level, those of type R go up one level and those of
+/// > type AN or EN go up two levels.
+/// >
+/// > **I2.** For all characters with an odd (right-to-left)
+/// > embedding level, those of type L, EN or AN go up one level.
+///
+/// The spec's Table 5 summarises the result:
+///
+/// | Type | Even EL | Odd EL |
+/// |------|---------|--------|
+/// | L    | EL      | EL + 1 |
+/// | R    | EL + 1  | EL     |
+/// | AN   | EL + 2  | EL + 1 |
+/// | EN   | EL + 2  | EL + 1 |
+///
+/// `BN` (Boundary Neutral) is **ignored** by I1 / I2 per UAX #9
+/// §5.3 HL3 ("In rules I1 and I2, ignore BN."). Operationally we
+/// keep `BN`s at the embedding level (they will be removed from the
+/// reorder when L-rules run); we do not promote them.
+///
+/// `NSM` (Nonspacing Mark) inherits the resolved type of the
+/// character it follows under W1 *before* this phase runs, so by
+/// the time `resolve_implicit_levels` is called the input slice
+/// (the same slice produced by [`resolve_weak_types`] then
+/// [`resolve_neutral_types`]) contains no `NSM` left to resolve via
+/// I1 / I2 except in the boundary case where a sequence opens with
+/// `NSM`s; W1 leaves those untouched (taking on `sos`). For the
+/// purposes of I1 / I2 those leftover `NSM`s are treated as `BN` —
+/// ignored.
+///
+/// # Inputs
+///
+/// - `classes`: the resolved bidirectional types for one isolating
+///   run sequence after [`resolve_weak_types`] + [`resolve_neutral_types`]
+///   have run. The slice must therefore contain only `L`, `R`, `EN`,
+///   `AN`, `NSM`, and `BN` — every `AL` has been collapsed to `R` by
+///   W3, every leftover `ES` / `ET` / `CS` has been collapsed to `ON`
+///   by W6 then collapsed to a strong direction by N1 / N2, and
+///   every NI (B / S / WS / ON / FSI / LRI / RLI / PDI) has been
+///   collapsed to a strong direction by N1 / N2.
+/// - `embedding_level`: the run's base embedding level — derived
+///   from the X-stack frame (or, for callers without X1..X10, the
+///   paragraph embedding level from [`paragraph_level`]).
+///
+/// # Output
+///
+/// A `Vec<u8>` of per-character embedding levels parallel to
+/// `classes`. Each entry is `embedding_level + 0..=2` per Table 5.
+/// The maximum value Unicode currently produces is
+/// `embedding_level + 2`, which can be `max_depth + 1` per the
+/// §3.3.6 note ("it is possible for text to end up at level
+/// `max_depth + 1` as a result of this process").
+///
+/// # Examples
+///
+/// ```
+/// use oxideav_scribe::bidi::{resolve_implicit_levels, BidiClass};
+///
+/// // Even (LTR) embedding level. L stays, R goes up 1, EN/AN go up 2.
+/// let cls = [
+///     BidiClass::L,
+///     BidiClass::R,
+///     BidiClass::EN,
+///     BidiClass::AN,
+/// ];
+/// assert_eq!(resolve_implicit_levels(&cls, 0), vec![0, 1, 2, 2]);
+///
+/// // Odd (RTL) embedding level. L, EN, AN all go up 1; R stays.
+/// let cls = [
+///     BidiClass::L,
+///     BidiClass::R,
+///     BidiClass::EN,
+///     BidiClass::AN,
+/// ];
+/// assert_eq!(resolve_implicit_levels(&cls, 1), vec![2, 1, 2, 2]);
+///
+/// // BN is ignored by I1 / I2 (stays at the embedding level).
+/// let cls = [BidiClass::BN, BidiClass::R];
+/// assert_eq!(resolve_implicit_levels(&cls, 0), vec![0, 1]);
+/// ```
+///
+/// Provenance: rules transcribed verbatim from
+/// `docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` §3.3.6 (UAX
+/// #9 Revision 50, Unicode 16.0) plus the §5.3 HL3 conformance
+/// clause ("In rules I1 and I2, ignore BN."). No external library
+/// source was consulted.
+#[must_use]
+pub fn resolve_implicit_levels(classes: &[BidiClass], embedding_level: u8) -> Vec<u8> {
+    let even = embedding_level % 2 == 0;
+    classes
+        .iter()
+        .map(|c| match c {
+            // BN is ignored per §5.3 HL3 — keep at embedding level.
+            // NSM left over from W1's sos boundary case is likewise
+            // ignored (treated as BN for this phase).
+            BidiClass::BN | BidiClass::NSM => embedding_level,
+            BidiClass::L => {
+                if even {
+                    embedding_level
+                } else {
+                    embedding_level + 1
+                }
+            }
+            BidiClass::R => {
+                if even {
+                    embedding_level + 1
+                } else {
+                    embedding_level
+                }
+            }
+            BidiClass::EN | BidiClass::AN => {
+                if even {
+                    embedding_level + 2
+                } else {
+                    embedding_level + 1
+                }
+            }
+            // Anything else is a caller contract violation (the input
+            // is expected to be the post-W + post-N output, which
+            // contains only L/R/EN/AN/NSM/BN). Defensive default:
+            // treat as the embedding direction so the per-character
+            // level is at least sensible.
+            _ => embedding_level,
+        })
+        .collect()
 }
 
 /// Split `text` into paragraphs at every character of class `B`
@@ -1738,5 +1889,125 @@ mod tests {
                 BidiClass::AN,
             ]
         );
+    }
+
+    // --- Section 6: I-rules (resolve_implicit_levels) -----------
+
+    #[test]
+    fn i_rules_empty_slice() {
+        let cls: Vec<BidiClass> = vec![];
+        assert_eq!(resolve_implicit_levels(&cls, 0), Vec::<u8>::new());
+        assert_eq!(resolve_implicit_levels(&cls, 1), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn i_rules_table5_even_level() {
+        // Table 5 row-for-row at embedding_level=0 (LTR).
+        let cls = [BidiClass::L, BidiClass::R, BidiClass::AN, BidiClass::EN];
+        assert_eq!(resolve_implicit_levels(&cls, 0), vec![0, 1, 2, 2]);
+    }
+
+    #[test]
+    fn i_rules_table5_odd_level() {
+        // Table 5 row-for-row at embedding_level=1 (RTL).
+        let cls = [BidiClass::L, BidiClass::R, BidiClass::AN, BidiClass::EN];
+        assert_eq!(resolve_implicit_levels(&cls, 1), vec![2, 1, 2, 2]);
+    }
+
+    #[test]
+    fn i_rules_higher_even_level() {
+        // Higher even embedding level (e.g. inside a nested LTR
+        // override). I1 still applies the same +1 / +2 deltas.
+        let cls = [BidiClass::L, BidiClass::R, BidiClass::EN];
+        assert_eq!(resolve_implicit_levels(&cls, 2), vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn i_rules_higher_odd_level() {
+        // Higher odd embedding level (e.g. inside a nested RTL
+        // override). I2 still applies the same +1 deltas.
+        let cls = [BidiClass::L, BidiClass::R, BidiClass::EN, BidiClass::AN];
+        assert_eq!(resolve_implicit_levels(&cls, 3), vec![4, 3, 4, 4]);
+    }
+
+    #[test]
+    fn i_rules_bn_ignored_per_hl3() {
+        // §5.3 HL3: "In rules I1 and I2, ignore BN." We model that
+        // by keeping BN at the embedding level — neither I1 nor I2
+        // touches it. Sandwich a BN inside a typical sequence:
+        let cls = [BidiClass::L, BidiClass::BN, BidiClass::R];
+        // Even level: L stays at 0, BN stays at 0, R goes to 1.
+        assert_eq!(resolve_implicit_levels(&cls, 0), vec![0, 0, 1]);
+        // Odd level: L goes to 2, BN stays at 1, R stays at 1.
+        assert_eq!(resolve_implicit_levels(&cls, 1), vec![2, 1, 1]);
+    }
+
+    #[test]
+    fn i_rules_nsm_leftover_treated_as_bn() {
+        // W1's sos boundary case leaves NSMs at the head of a
+        // sequence untouched ("the second NSM... sees the first").
+        // For I1 / I2 those leftover NSMs are treated as BN — kept
+        // at the embedding level.
+        let cls = [BidiClass::NSM, BidiClass::R];
+        assert_eq!(resolve_implicit_levels(&cls, 0), vec![0, 1]);
+        assert_eq!(resolve_implicit_levels(&cls, 1), vec![1, 1]);
+    }
+
+    #[test]
+    fn i_rules_pure_ltr_run_stays_flat() {
+        // An all-L run at even level produces no level change.
+        let cls = [BidiClass::L; 5];
+        assert_eq!(resolve_implicit_levels(&cls, 0), vec![0; 5]);
+        // At odd level every L is promoted by one.
+        assert_eq!(resolve_implicit_levels(&cls, 1), vec![2; 5]);
+    }
+
+    #[test]
+    fn i_rules_pure_rtl_run_stays_flat() {
+        // An all-R run at odd level produces no level change.
+        let cls = [BidiClass::R; 5];
+        assert_eq!(resolve_implicit_levels(&cls, 1), vec![1; 5]);
+        // At even level every R is promoted by one.
+        assert_eq!(resolve_implicit_levels(&cls, 0), vec![1; 5]);
+    }
+
+    #[test]
+    fn i_rules_numbers_always_higher_than_paragraph_level() {
+        // §3.3.6 narrative guarantee: "numeric text will always end
+        // up with a higher level than the paragraph level". Test
+        // both EN and AN at even and odd levels.
+        let cls = [BidiClass::EN, BidiClass::AN];
+        for el in 0u8..4 {
+            let levels = resolve_implicit_levels(&cls, el);
+            assert!(
+                levels.iter().all(|&l| l > el),
+                "EN/AN > paragraph level at el={el}"
+            );
+        }
+    }
+
+    #[test]
+    fn i_rules_compose_with_w_and_n_pipeline() {
+        // Realistic mini-pipeline: start with the W6 example
+        // `L EN ON R` (numbers in LTR text followed by an Arabic
+        // word). After W7 EN becomes L; N1 then makes the ON
+        // between L and R take the embedding direction (N2 fallback
+        // at embedding_level=0 → L). Then I rules promote R.
+        let mut cls = vec![BidiClass::L, BidiClass::EN, BidiClass::ON, BidiClass::R];
+        resolve_weak_types(&mut cls, BidiClass::L, BidiClass::L);
+        // W7 turns EN→L because the most-recent strong is L.
+        assert_eq!(
+            cls,
+            vec![BidiClass::L, BidiClass::L, BidiClass::ON, BidiClass::R]
+        );
+        resolve_neutral_types(&mut cls, 0, BidiClass::L, BidiClass::L);
+        // N2 fallback (L on left, R on right, mismatch → embedding
+        // direction = L at embedding_level 0).
+        assert_eq!(
+            cls,
+            vec![BidiClass::L, BidiClass::L, BidiClass::L, BidiClass::R]
+        );
+        let levels = resolve_implicit_levels(&cls, 0);
+        assert_eq!(levels, vec![0, 0, 0, 1]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,17 @@
 //!   pass (rules N1 + N2): every maximal NI run (B / S / WS / ON /
 //!   LRI / RLI / FSI / PDI) collapses to a strong direction —
 //!   matching neighbours via N1 (with `EN` / `AN` counting as `R`)
-//!   or the embedding direction via N2. The bracket-pair rule N0
-//!   and the I / X / L rules are deferred to follow-up rounds.
+//!   or the embedding direction via N2. Round 204 lands
+//!   `bidi::resolve_implicit_levels(classes, embedding_level) ->
+//!   Vec<u8>`, the §3.3.6 implicit-level resolution (rules I1 + I2):
+//!   per Table 5, even-level R climbs +1 and AN/EN climb +2;
+//!   odd-level L / EN / AN climb +1; `BN` (and any W1-leftover
+//!   `NSM`) is ignored per HL3. After this phase RTL text always
+//!   sits at an odd level, LTR + numeric text at even, and numeric
+//!   text strictly above the paragraph level — exactly the
+//!   precondition the L-rules (line reordering) consume. The
+//!   bracket-pair rule N0 and the X / L rules are deferred to
+//!   follow-up rounds.
 //!
 //! See `README.md` for a tour and the deferral list.
 
@@ -114,8 +123,8 @@ pub mod style;
 pub mod variations;
 
 pub use bidi::{
-    bidi_class, paragraph_level, resolve_neutral_types, resolve_weak_types, split_paragraphs,
-    BidiClass,
+    bidi_class, paragraph_level, resolve_implicit_levels, resolve_neutral_types,
+    resolve_weak_types, split_paragraphs, BidiClass,
 };
 pub use color::{Rgba, TRANSPARENT, WHITE};
 pub use color_glyph::ColorGlyphBitmap;

--- a/tests/round204_bidi_implicit_levels.rs
+++ b/tests/round204_bidi_implicit_levels.rs
@@ -1,0 +1,261 @@
+//! Round 204 — UAX #9 §3.3.6 implicit-level resolution (rules I1 +
+//! I2) integration tests.
+//!
+//! Mirrors the per-rule unit tests in `src/bidi.rs` but exercises the
+//! public `oxideav_scribe::resolve_implicit_levels` re-export so the
+//! surface stays stable for external callers, and composes the I-rule
+//! pass with the W- and N-rule passes from earlier rounds to verify
+//! the end-to-end pipeline matches the spec narrative ("right-to-left
+//! text will always end up with an odd level, and left-to-right and
+//! numeric text will always end up with an even level... numeric text
+//! will always end up with a higher level than the paragraph level").
+//!
+//! Provenance: every input is constructed by hand from the rule
+//! examples and Table 5 in UAX #9 Revision 50 / Unicode 16.0 §3.3.6
+//! (the dated snapshot at
+//! `docs/text/unicode-bidi/tr9-50-uax9-unicode16.html`) plus the
+//! §5.3 HL3 conformance clause ("In rules I1 and I2, ignore BN.").
+//! No external library source — HarfBuzz, ICU, FreeType, rustybuzz,
+//! the `unicode-bidi` crate, etc. — was consulted at any point.
+
+use oxideav_scribe::{
+    resolve_implicit_levels, resolve_neutral_types, resolve_weak_types, BidiClass,
+};
+
+#[test]
+fn r204_public_resolve_implicit_levels_empty_is_noop() {
+    let cls: Vec<BidiClass> = vec![];
+    assert!(resolve_implicit_levels(&cls, 0).is_empty());
+    assert!(resolve_implicit_levels(&cls, 1).is_empty());
+}
+
+#[test]
+fn r204_public_table5_at_paragraph_level_0() {
+    // Table 5 row-for-row at embedding_level=0 (LTR paragraph).
+    let cls = [BidiClass::L, BidiClass::R, BidiClass::AN, BidiClass::EN];
+    assert_eq!(resolve_implicit_levels(&cls, 0), vec![0, 1, 2, 2]);
+}
+
+#[test]
+fn r204_public_table5_at_paragraph_level_1() {
+    // Table 5 row-for-row at embedding_level=1 (RTL paragraph).
+    let cls = [BidiClass::L, BidiClass::R, BidiClass::AN, BidiClass::EN];
+    assert_eq!(resolve_implicit_levels(&cls, 1), vec![2, 1, 2, 2]);
+}
+
+#[test]
+fn r204_public_table5_at_higher_even_level() {
+    // Nested LTR override at embedding_level=2: same deltas as
+    // embedding_level=0, shifted by 2.
+    let cls = [BidiClass::L, BidiClass::R, BidiClass::AN, BidiClass::EN];
+    assert_eq!(resolve_implicit_levels(&cls, 2), vec![2, 3, 4, 4]);
+}
+
+#[test]
+fn r204_public_table5_at_higher_odd_level() {
+    // Nested RTL override at embedding_level=3: same deltas as
+    // embedding_level=1, shifted by 2.
+    let cls = [BidiClass::L, BidiClass::R, BidiClass::AN, BidiClass::EN];
+    assert_eq!(resolve_implicit_levels(&cls, 3), vec![4, 3, 4, 4]);
+}
+
+#[test]
+fn r204_public_bn_ignored_per_hl3_at_even_level() {
+    // §5.3 HL3: "In rules I1 and I2, ignore BN." BN keeps the
+    // embedding level even when surrounded by promoted types.
+    let cls = [
+        BidiClass::L,
+        BidiClass::BN,
+        BidiClass::R,
+        BidiClass::BN,
+        BidiClass::EN,
+    ];
+    assert_eq!(resolve_implicit_levels(&cls, 0), vec![0, 0, 1, 0, 2]);
+}
+
+#[test]
+fn r204_public_bn_ignored_per_hl3_at_odd_level() {
+    let cls = [
+        BidiClass::L,
+        BidiClass::BN,
+        BidiClass::R,
+        BidiClass::BN,
+        BidiClass::EN,
+    ];
+    assert_eq!(resolve_implicit_levels(&cls, 1), vec![2, 1, 1, 1, 2]);
+}
+
+#[test]
+fn r204_public_nsm_leftover_treated_as_bn() {
+    // W1's sos boundary case leaves NSMs at the head of an
+    // isolating run sequence untouched. For I1 / I2 those leftover
+    // NSMs are treated as BN (kept at embedding level).
+    let cls = [BidiClass::NSM, BidiClass::NSM, BidiClass::R];
+    assert_eq!(resolve_implicit_levels(&cls, 0), vec![0, 0, 1]);
+    assert_eq!(resolve_implicit_levels(&cls, 1), vec![1, 1, 1]);
+}
+
+#[test]
+fn r204_public_pure_ltr_run_at_even_level_is_flat() {
+    let cls = [BidiClass::L; 8];
+    assert_eq!(resolve_implicit_levels(&cls, 0), vec![0; 8]);
+}
+
+#[test]
+fn r204_public_pure_rtl_run_at_odd_level_is_flat() {
+    let cls = [BidiClass::R; 8];
+    assert_eq!(resolve_implicit_levels(&cls, 1), vec![1; 8]);
+}
+
+#[test]
+fn r204_public_numbers_always_above_paragraph_level() {
+    // §3.3.6 narrative guarantee: "numeric text will always end up
+    // with a higher level than the paragraph level".
+    let cls = [BidiClass::EN, BidiClass::AN];
+    for el in 0u8..6 {
+        let levels = resolve_implicit_levels(&cls, el);
+        assert!(
+            levels.iter().all(|&l| l > el),
+            "EN/AN must climb above paragraph level at el={el}, got {levels:?}",
+        );
+    }
+}
+
+#[test]
+fn r204_public_rtl_always_ends_odd_when_starting_ltr() {
+    // §3.3.6 narrative: "Right-to-left text will always end up with
+    // an odd level". An R-classed character starting at any even
+    // level ends odd.
+    for el in (0u8..8).step_by(2) {
+        let levels = resolve_implicit_levels(&[BidiClass::R], el);
+        assert_eq!(
+            levels[0] % 2,
+            1,
+            "R at even el={el} must end odd, got {}",
+            levels[0]
+        );
+    }
+}
+
+#[test]
+fn r204_public_ltr_always_ends_even_when_starting_rtl() {
+    // §3.3.6 narrative: "left-to-right and numeric text will always
+    // end up with an even level". An L-classed character starting
+    // at any odd level ends even.
+    for el in (1u8..8).step_by(2) {
+        let levels = resolve_implicit_levels(&[BidiClass::L], el);
+        assert_eq!(
+            levels[0] % 2,
+            0,
+            "L at odd el={el} must end even, got {}",
+            levels[0]
+        );
+    }
+}
+
+#[test]
+fn r204_public_pipeline_w_n_then_i_ltr_paragraph() {
+    // End-to-end mini-pipeline on a representative mixed sequence:
+    //   [L, EN, ON, R]  (hypothetical "abc 123 . xyz" where xyz is Arabic)
+    // at LTR paragraph (embedding_level=0).
+    //
+    //   W7: EN whose most-recent strong is L flips to L.
+    //                    → [L, L, ON, R]
+    //   N2: ON with L on the left and R on the right (mismatch)
+    //       falls back to embedding direction L.
+    //                    → [L, L, L, R]
+    //   I1: L stays at 0, R climbs to 1.
+    //                    → [0, 0, 0, 1]
+    let mut cls = vec![BidiClass::L, BidiClass::EN, BidiClass::ON, BidiClass::R];
+    resolve_weak_types(&mut cls, BidiClass::L, BidiClass::L);
+    assert_eq!(
+        cls,
+        vec![BidiClass::L, BidiClass::L, BidiClass::ON, BidiClass::R]
+    );
+    resolve_neutral_types(&mut cls, 0, BidiClass::L, BidiClass::L);
+    assert_eq!(
+        cls,
+        vec![BidiClass::L, BidiClass::L, BidiClass::L, BidiClass::R]
+    );
+    assert_eq!(resolve_implicit_levels(&cls, 0), vec![0, 0, 0, 1]);
+}
+
+#[test]
+fn r204_public_pipeline_w_n_then_i_rtl_paragraph_arabic_phone() {
+    // End-to-end on the Arabic-phone-style sequence from round 191:
+    //   [AL, NSM, EN, ET, EN, CS, AN]  with sos=eos=R at
+    //   embedding_level=1 (RTL paragraph).
+    //
+    //   W1..W7: → [R, R, AN, ON, AN, AN, AN]  (per the existing
+    //           full-pipeline test in src/bidi.rs).
+    //   N1 / N2: the lone ON has AN on both sides; AN counts as R
+    //            in N1, so N1 collapses it to R.
+    //           → [R, R, AN, R, AN, AN, AN]
+    //   I2 (odd embedding level): R stays at 1, AN climbs by 1
+    //       → 2.
+    //           → [1, 1, 2, 1, 2, 2, 2]
+    let mut cls = vec![
+        BidiClass::AL,
+        BidiClass::NSM,
+        BidiClass::EN,
+        BidiClass::ET,
+        BidiClass::EN,
+        BidiClass::CS,
+        BidiClass::AN,
+    ];
+    resolve_weak_types(&mut cls, BidiClass::R, BidiClass::R);
+    assert_eq!(
+        cls,
+        vec![
+            BidiClass::R,
+            BidiClass::R,
+            BidiClass::AN,
+            BidiClass::ON,
+            BidiClass::AN,
+            BidiClass::AN,
+            BidiClass::AN,
+        ]
+    );
+    resolve_neutral_types(&mut cls, 1, BidiClass::R, BidiClass::R);
+    // N1 collapses the ON between two AN-as-R neighbours to R.
+    assert_eq!(
+        cls,
+        vec![
+            BidiClass::R,
+            BidiClass::R,
+            BidiClass::AN,
+            BidiClass::R,
+            BidiClass::AN,
+            BidiClass::AN,
+            BidiClass::AN,
+        ]
+    );
+    assert_eq!(resolve_implicit_levels(&cls, 1), vec![1, 1, 2, 1, 2, 2, 2]);
+}
+
+#[test]
+fn r204_public_pipeline_ascending_levels_within_paragraph() {
+    // Demonstrate that the per-character levels emitted form a
+    // valid reordering precondition: every odd-level character is
+    // RTL-aligned (R), every even-level character is LTR-aligned
+    // (L) or numeric (EN/AN).
+    let cls = vec![
+        BidiClass::L,
+        BidiClass::EN,
+        BidiClass::R,
+        BidiClass::AN,
+        BidiClass::L,
+    ];
+    let levels = resolve_implicit_levels(&cls, 0);
+    for (c, &l) in cls.iter().zip(levels.iter()) {
+        match c {
+            BidiClass::L => assert_eq!(l % 2, 0),
+            BidiClass::R => assert_eq!(l % 2, 1),
+            BidiClass::EN | BidiClass::AN => {
+                assert_eq!(l % 2, 0);
+                assert!(l > 0, "numbers must be above paragraph level 0");
+            }
+            _ => unreachable!(),
+        }
+    }
+}


### PR DESCRIPTION



## 🤖 New release

* `oxideav-scribe`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.8...v0.1.9) - 2026-06-01

### Other

- UAX #9 implicit-level resolution rules I1 + I2 (round 204)

### Added — UAX #9 §3.3.6 implicit-level resolution rules I1 + I2 (round 204)

Fourth concrete UAX #9 surface on scribe, layered directly on top
of the round 198 neutral-type pass: the §3.3.6 implicit-level
resolution rules I1 and I2. The phase consumes the resolved
bidirectional types (the post-W, post-N output containing only
`L` / `R` / `EN` / `AN` / `NSM` / `BN`) plus the run's base
embedding level and emits one **embedding level per character**,
which is the precondition the future §3.4 L-rules (line-level
reordering) consume.

- **`bidi::resolve_implicit_levels(classes: &[BidiClass],
  embedding_level: u8) -> Vec<u8>`** — applies Table 5 row-by-row:
  - At an **even (LTR)** base level: `L` stays, `R` climbs by 1,
    `AN` / `EN` climb by 2 (I1).
  - At an **odd (RTL)** base level: `R` stays, `L` / `EN` / `AN`
    climb by 1 (I2).
  - `BN` is ignored per the §5.3 HL3 conformance clause ("In rules
    I1 and I2, ignore BN.") — it keeps the embedding level rather
    than being promoted. Any W1-leftover `NSM` from the boundary
    case where the sequence opens with an `NSM` is treated the
    same.
- **`oxideav_scribe::resolve_implicit_levels`** + the matching
  `oxideav_scribe::bidi::resolve_implicit_levels` — public re-
  exports alongside `resolve_weak_types` and `resolve_neutral_types`.

After the pass the per-character levels satisfy the §3.3.6
narrative guarantees:

1. RTL text always ends up at an **odd** level.
2. LTR + numeric text always ends up at an **even** level.
3. Numeric text always ends up at a level **strictly higher** than
   the paragraph level.

**27 new tests** (11 unit + 16 integration via
`tests/round204_bidi_implicit_levels.rs`): every Table-5 row at
both even and odd base levels, higher nested override levels (e.g.
`embedding_level=2` and `=3`), the BN-ignored case at both
parities, W1-leftover NSM treatment at the head of a sequence, the
three narrative guarantees enforced across a range of paragraph
levels, and two realistic compose-with-W-and-N pipelines: an LTR
paragraph `[L, EN, ON, R]` walking through W7's EN-after-L → L,
N2's L/R-mismatch ON → L embedding-direction fallback, and I1's
R → 1 promotion; and the round-191 RTL Arabic-phone-style
`[AL, NSM, EN, ET, EN, CS, AN]` sequence walking through all of
W1..W7, then N1's AN/AN-as-R collapse of the lone ON, then I2's
AN → +1 promotion.

**X / L rules remain deferred**; N0 (bracket-pair resolution) is
still blocked on the Unicode `BidiBrackets.txt` data file not
being vendored under `docs/`.

Provenance: rules transcribed verbatim from
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` §3.3.6
(UAX #9 Revision 50, Unicode 16.0) plus the §5.3 HL3
conformance clause. No external library source consulted — no
ICU / HarfBuzz / FriBidi / minikin / `unicode-bidi` crate /
upstream reference engine reached at any point.

### Added — UAX #9 §3.3.5 neutral-type resolution rules N1 + N2 (round 198)

Third concrete UAX #9 surface on scribe, layered on top of the
round 191 weak-type pass: the §3.3.5 neutral / isolate-formatting
resolution rules N1 and N2. The phase finishes resolving every
former neutral or isolate-formatting position to a strong
direction, completing the input vocabulary the §3.3.6 implicit-
level pass (I1 / I2) will consume in a follow-up round.

- **`bidi::resolve_neutral_types(classes: &mut [BidiClass],
  embedding_level: u8, sos: BidiClass, eos: BidiClass)`** — in-place
  pass over one isolating run sequence (the same slice already
  mutated by `resolve_weak_types`) applying:
  - **N1** — every maximal contiguous run of NI elements (`B` /
    `S` / `WS` / `ON` / `LRI` / `RLI` / `FSI` / `PDI`) collapses to
    the strong type on either side when both sides agree, with `EN`
    and `AN` counting as `R` per the spec's "European and Arabic
    numbers act as if they were R". `NSM` / `BN` are skipped by the
    strong-side walk (they are non-strong but also non-NI). `sos` /
    `eos` provide the strong type at sequence boundaries.
  - **N2** — every NI run whose strong neighbours disagree
    collapses to the embedding direction (`L` for even
    `embedding_level`, `R` for odd).
- **`oxideav_scribe::resolve_neutral_types`** + the matching
  `oxideav_scribe::bidi::resolve_neutral_types` — public re-exports
  alongside `resolve_weak_types`.

After the pass the slice contains no NI; `NSM` and `BN` survive
untouched (they are not in the NI alias and the §3.3.6 implicit-
level rules handle them).

**N0 (bracket-pair resolution per §3.1.3 + §3.3.5) is deferred** —
it requires the Unicode `BidiBrackets.txt` data file to identify
opening / closing paired brackets, which is not yet vendored under
`docs/`. The N1 / N2 surface is forward-compatible: an N0
implementation lands as a pre-N1 pass that turns bracket positions
into strong types, after which N1 / N2 continues to apply
unchanged.

**21 new tests** (10 unit + 11 integration via
`tests/round198_bidi_neutral_types.rs`): every spec example —
`L NI L → L L L`, `R NI R → R R R`, the full R / AN / EN N1 table
with EN / AN counting as R, the N2 mismatch table at both
embedding levels, the full NI alias collapsing in one run,
`NSM` / `BN` pass-through across NI boundaries, `sos` / `eos`
driving boundary-spanning runs, idempotence on NI-free slices,
and the compose-with-W realistic Arabic + numbers pipeline.

Provenance: rules transcribed verbatim from
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` §3.3.5 (UAX #9
Revision 50, Unicode 16.0). No external library source was
consulted at any point.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).