### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.8...v0.1.9) - 2026-06-15
+
+### Other
+
+- refresh to current status, drop per-round changelog cruft
+- GPOS LookupType 5 mark-to-ligature attachment (round 304)
+- wire GPOS LookupType 1 single adjustment positioning (round 298)
+- round 291 — reorder_line_visual high-level bidi bridge
+- UAX #9 lookups data-driven from Unicode 16.0 UCD tables (round 283)
+- GPOS LookupType 3 cursive attachment (round 276)
+- UAX #9 §3.4 L4 bidi mirroring (round 268)
+- UAX #9 §3.3.5 N0 bracket-pair resolution (round 257)
+- drop release-plz.toml — use release-plz defaults across the workspace
+- UAX #9 §3.4 L3 combining-mark reordering (round 247)
+- UAX #9 §3.3.1 P1 multi-paragraph driver (round 233)
+- r227 test-count correction (14 → 19 unit)
+- UAX #9 §3 whole-paragraph driver (round 227)
+- UAX #9 §3.3.3 X10 isolating-run-sequence partition + sos/eos (round 220)
+- UAX #9 §3.3.2 explicit-level / override / isolate stack X1..X9 (round 217)
+- UAX #9 line-level reordering rules L1 + L2 (round 210)
+- UAX #9 implicit-level resolution rules I1 + I2 (round 204)
+
 ### Added — GPOS LookupType 5 mark-to-ligature attachment (round 304)
 
 The shaper's mark-attachment pass now positions combining marks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxideav-scribe"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `oxideav-scribe`: 0.1.8 -> 0.1.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/OxideAV/oxideav-scribe/compare/v0.1.8...v0.1.9) - 2026-06-15

### Other

- refresh to current status, drop per-round changelog cruft
- GPOS LookupType 5 mark-to-ligature attachment (round 304)
- wire GPOS LookupType 1 single adjustment positioning (round 298)
- round 291 — reorder_line_visual high-level bidi bridge
- UAX #9 lookups data-driven from Unicode 16.0 UCD tables (round 283)
- GPOS LookupType 3 cursive attachment (round 276)
- UAX #9 §3.4 L4 bidi mirroring (round 268)
- UAX #9 §3.3.5 N0 bracket-pair resolution (round 257)
- drop release-plz.toml — use release-plz defaults across the workspace
- UAX #9 §3.4 L3 combining-mark reordering (round 247)
- UAX #9 §3.3.1 P1 multi-paragraph driver (round 233)
- r227 test-count correction (14 → 19 unit)
- UAX #9 §3 whole-paragraph driver (round 227)
- UAX #9 §3.3.3 X10 isolating-run-sequence partition + sos/eos (round 220)
- UAX #9 §3.3.2 explicit-level / override / isolate stack X1..X9 (round 217)
- UAX #9 line-level reordering rules L1 + L2 (round 210)
- UAX #9 implicit-level resolution rules I1 + I2 (round 204)

### Added — GPOS LookupType 5 mark-to-ligature attachment (round 304)

The shaper's mark-attachment pass now positions combining marks
against **ligature** base glyphs via GPOS LookupType 5 (MarkLigPos).
Per the OpenType GPOS chapter, a ligature carries "multiple components
(in a virtual sense — not actual glyphs)", each with its own per-class
attachment anchors, and the component a mark associates with "is
dependent on the original character string and subsequent ...
glyph-substitution operations". The shaper recovers that association
from its own ligature-collapse pass: each output glyph now records how
many input glyphs collapsed into it (the component count). When a mark
walks back to a multi-component ligature base, the mark-to-ligature
path runs first — the trailing mark is associated with the **last**
component by default (the "fi + dot-above" case, where the dot
followed the second component), and the probe walks down toward
component 0 so a mark still lands on whichever component publishes a
non-NULL class anchor. A ligature that ships no LookupType-5 anchor
for the mark falls back to mark-to-base; a non-ligature base keeps the
existing mark-to-base path unchanged. Component tracking is reset to
all-single-component when `calt` reshapes the run (a length change
breaks positional alignment), so the type-5 path simply does not fire
on a calt-mutated run rather than mis-indexing. 6 integration tests
build a synthetic TTF (GSUB ligature + GDEF mark class + GPOS
MarkLigPos) and cover last-component attachment, size scaling, the
NULL/out-of-range-component fallback to component 0, the
no-ligature-no-type-5 case, the no-GPOS no-op, and that plain
ligature substitution is undisturbed.

### Added — GPOS LookupType 1 single adjustment positioning (round 298)

The shaper's positioning pipeline now runs a GPOS LookupType 1
(SinglePos) pass between kerning and mark attachment. Per the OpenType
GPOS chapter a SinglePos subtable "is used to adjust the placement or
advance of a single glyph, such as a subscript or superscript"; both
SinglePosFormat1 (one shared `ValueRecord` for every covered glyph)
and SinglePosFormat2 (a per-glyph `ValueRecord` array) are honoured.
The four `ValueRecord` geometric fields map onto a positioned glyph
as: `xPlacement` adds to `x_offset`, `yPlacement` subtracts from
`y_offset` (TT Y-up → raster Y-down), and `xAdvance` widens or
narrows the horizontal advance; `yAdvance` (vertical layout only) is
ignored on the horizontal pen. The pass is gated on the font
publishing a LookupType-1 lookup, so plain fonts pay only one
lookup-list scan, and runs before mark attachment so the
mark-to-base advance accumulation sees the adjusted base advances.
Coverage misses leave the glyph untouched. 6 integration tests cover
Format 1 shared-value application, Format 2 per-glyph independence,
size scaling, additive stacking with the kern `x_offset`, the
no-GPOS no-op, and the uncovered-glyph pass-through.

### Added — high-level bidirectional layout bridge (round 291)

`layout::reorder_line_visual(text, base_level) -> VisualLine` drives
the complete UAX #9 §3 + §3.4 pipeline (P → X → W → N0 → N1 / N2 →
I → L1 → L2 → L3 → L4) over a single display line and returns its
characters in left-to-right visual order, ready to feed glyph-by-glyph
into the shaper. This is the first time the `layout::*` API drives the
bidi engine automatically — previously callers wired the per-character
permutation into their own renderer.

The `VisualLine` carrier publishes `visual: Vec<char>` (L4-mirrored,
render-order), the `logical_to_visual` / `visual_to_logical`
permutation pair (the inverse precomputed for O(1) cursor
hit-testing), and the resolved `base_level`. `base_level: Option<u8>`
is the HL1 higher-level-protocol override (`Some(0)` LTR, `Some(1)`
RTL, `None` lets P2 / P3 resolve from the first strong character). The
internal composition runs `process_paragraph_classes_with_brackets`
(bracket-aware N0) followed by `reset_trailing_levels` (L1),
`reorder_line` (L2), `reorder_combining_marks` (L3) and
`apply_mirroring` (L4); the full per-rule `bidi::` surface stays public
for callers needing finer control. 9 unit + 12 integration tests cover
LTR identity, pure-RTL reversal, embedded-island ordering in both
directions, L4 bracket mirroring in RTL vs LTR context, digits staying
LTR in an RTL line, Arabic-letter base resolution, the HL1 override,
the permutation bijection / inverse-consistency / hit-test round-trip
invariants, and the §3.4 "car means CAR." worked example.

### Added — UAX #9 Unicode 16.0 UCD data tables (round 283)

The three bidi property lookups are now data-driven from the Unicode
16.0 UCD snapshots staged under `docs/text/unicode-bidi/` and
vendored verbatim into `src/bidi/` (embedded via `include_str!`,
parsed once on first lookup into sorted binary-searched range
tables behind `OnceLock`s):

- **`bidi::bidi_class(c)`** — full per-code-point `Bidi_Class` from
  `DerivedBidiClass.txt` (2289 explicit ranges), replacing the
  previous hand-mapped block list. The file's `@missing` lines are
  honoured for unassigned code points: `R` / `AL` defaults in the
  blocks reserved for right-to-left scripts, `ET` in the Currency
  Symbols block, global `L` fallback elsewhere. ASCII punctuation
  such as `!` / `"` that previously fell through to the `L` default
  now resolves to its UCD class (`ON`), and noncharacters resolve
  to `BN`.
- **`bidi::paired_bracket(c)`** — full normative
  `Bidi_Paired_Bracket` / `Bidi_Paired_Bracket_Type` table from
  `BidiBrackets.txt` (64 open/close pairs: ASCII, Tibetan gug
  rtags, square-bracket-with-quill, mathematical, CJK / fullwidth),
  replacing the six-ASCII-bracket seed table from round 257. The
  BD16 walker's close-branch comparison now implements the "where
  U+3009 and U+232A are treated as equivalent"
  canonical-equivalence clause, so mixed U+2329/U+3009 and
  U+3008/U+232A bracket pairs are identified.
- **`bidi::mirrored_glyph(c)`** — full informative
  `Bidi_Mirroring_Glyph` table from `BidiMirroring.txt` (428
  entries — brackets, angle quotation marks, mathematical
  relations and operators, CJK brackets), replacing the
  six-ASCII-bracket seed table from round 268, so rule L4 now
  mirrors `<` ↔ `>`, `«` ↔ `»`, `≤` ↔ `≥`, `〈` ↔ `〉`, … at odd
  resolved levels.

4 unit tests pin the table-size / sortedness / involution /
open-close-symmetry / brackets-are-ON-and-mirrored invariants
straight off the parsed tables; 11 integration tests
(`round283_bidi_unicode_data_tables.rs`) cover explicit class
assignments across planes, the `@missing` fallbacks, noncharacter
BN, the BD16 canonical-equivalence pairings, and N0 + L4
end-to-end through `process_paragraph_with_brackets` with
non-ASCII brackets and mirrors. No public API change — the three
lookup signatures are unchanged.

### Added — GPOS LookupType 3 cursive attachment (round 276)

The shaper's positioning pipeline grows a sixth step: **cursive
attachment** (GPOS LookupType 3, CursivePosFormat1), the
exit-anchor → entry-anchor joining pass that connects adjacent
glyphs in joining scripts. Per the GPOS chapter's CursivePos
section, the two axes work differently and both are implemented:

- **Line-layout direction (X)** — "the layout engine adjusts the
  advance of the first glyph (in logical order)": the first glyph's
  `x_advance` is rewritten so the second glyph's entry anchor lands
  exactly on the first glyph's exit anchor, accounting for both
  glyphs' `x_offset`s and any intervening zero-advance marks.
- **Cross-stream direction (Y)** — "placement of one glyph is
  adjusted to make the anchors align": with the parent lookup's
  RIGHT_TO_LEFT flag clear, the **second** glyph's `y_offset` moves
  to the first glyph's exit height. Adjustments accumulate down a
  connected chain (each second glyph is placed relative to the
  already-adjusted first), producing the cascading-baseline
  behaviour cursive scripts need. Marks attached to the second
  glyph follow it vertically; no X fix-up is needed because the
  advance rewrite shifts the pen of the second glyph and its
  trailing marks equally.

NULL entry/exit anchor offsets skip the pair ("no positioning
adjustment is applied" per spec); fonts without any LookupType-3
lookup skip the pass entirely (one `gpos_lookup_list` probe per
run). The pass runs after mark attachment so cursive chains walk
consecutive **non-mark** glyphs. Scope note: the RIGHT_TO_LEFT
flag-**set** variant (first glyph adjusted cross-stream, chain
anchored to the last glyph's baseline position) needs the GPOS
lookup flag, which `oxideav-ttf`'s public API does not yet expose —
deferred.

Verified by `tests/round276_cursive_attachment.rs`: a synthetic
4-glyph TTF carrying one `curs` feature / CursivePosFormat1 lookup
(byte layout per the staged GPOS / Coverage / Anchor-Format-1 spec
tables) exercises exact anchor alignment, chain accumulation,
px-size scaling, NULL-anchor skips, and the no-GPOS no-op.

### Added — UAX #9 §3.4 L4 bidi mirroring (round 268)

Twelfth UAX #9 surface on scribe and the final entry in the §3.4
line-level pass: rule **L4**, the mirrored-glyph selection for
characters whose resolved directionality is R, shipped — like the
round-257 N0 pass — with the algorithm complete and the lookup
table seeded from the ASCII paired-bracket set pending the
`BidiMirroring.txt` vendoring.

- **`bidi::mirrored_glyph(c: char) -> Option<char>`** — the
  `Bidi_Mirroring_Glyph` acceptable-mirror-pair lookup for the six
  ASCII paired brackets (`(` ↔ `)`, `[` ↔ `]`, `{` ↔ `}`). The
  mapping is an involution (`mirrored_glyph(m) == Some(c)` whenever
  `mirrored_glyph(c) == Some(m)`) and agrees with the round-257
  `paired_bracket` lookup on the seed set. Per the §3.4 L4
  backward-compatibility note, U+FD3E / U+FD3F ORNATE LEFT / RIGHT
  PARENTHESIS are **not** mirrored and return `None`. The full
  mirrored-pair catalogue is the informative `BidiMirroring.txt`
  data file from the UCD, not yet vendored under
  `docs/text/unicode-bidi/`; callers needing the wider set
  (mathematical operators, angle brackets, CJK bracket blocks) can
  run the same per-position loop against their own
  `char -> Option<char>` lookup.
- **`bidi::apply_mirroring(chars: &mut [char], levels: &[u8])`** —
  rule **L4** applied in place to a line's logical character
  sequence: "A character is depicted by a mirrored glyph if and
  only if (a) the resolved directionality of that character is R,
  and (b) the Bidi_Mirrored property value of that character is
  Yes." Condition (a) is read off the resolved level vector (odd
  level ⇔ directionality R per the §3.2 even-LTR / odd-RTL level
  convention); condition (b) is the `mirrored_glyph` lookup, with
  the replacement realising the spec's "depicted by a mirrored
  glyph" requirement through the §7 acceptable-mirror-pair
  substitution. L4 is a per-position glyph selection independent
  of the L2 / L3 permutation; the documented composition applies
  it to the logical sequence and then walks the L2 permutation.
  Because the lookup is an involution, double application restores
  the input — callers run it exactly once per rendered line. The
  HL6 higher-level-protocol override is out of scope. Panics on
  `chars` / `levels` length mismatch.
- **`oxideav_scribe::mirrored_glyph`** +
  **`oxideav_scribe::apply_mirroring`** — public re-exports
  alongside the existing W / N / I / X / L surface.
- **13 unit tests + 19 integration tests**
  (`tests/round268_bidi_l4_mirroring.rs`) cover the seed-pair
  round-trips, the involution + paired-bracket agreement
  invariants, the ornate-parentheses exclusion, the §3.4 worked
  example (`(` even-level vs odd-level), mixed / higher-odd level
  dispatch, non-mirrored pass-through at odd levels, empty input,
  double-application restore, the length-mismatch panic, and
  end-to-end compositions through
  `process_paragraph_with_brackets` + L1 → L2 → L3 → L4 on RTL
  Hebrew lines carrying bracket pairs and combining marks
  (including the display-stream assertion that mirrored brackets
  open toward the enclosed text in visual order). Total scribe
  tests: 861 → 895.

Out-of-scope tail (`README.md`): the `BidiMirroring.txt`
mirrored-pair table needs to land under `docs/text/unicode-bidi/`
before `mirrored_glyph` can grow past the ASCII paired-bracket
seed set — same shape as the `BidiBrackets.txt` gap blocking the
wider N0 table. The L4 algorithm itself is complete; only the
lookup table is partial. With L4 landed, every UAX #9 rule scribe
tracks (P / X / W / N0 / N1 / N2 / I / L1 / L2 / L3 / L4) now has
an implementation; the remaining BiDi work is data-file vendoring
(`BidiBrackets.txt`, `BidiMirroring.txt`, `DerivedBidiClass.txt`)
plus wiring the pipeline into the high-level `layout::*` API.

Provenance: rule L4 and the §7 *Mirroring* acceptable-pair note are
transcribed verbatim from UAX #9 Revision 50 / Unicode 16.0
(`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html`).

### Added — UAX #9 §3.3.5 N0 bracket-pair resolution (round 257)

Eleventh UAX #9 surface on scribe and the first entry to land the
bracket-pair phase of the §3.3.5 neutral pass: rule **N0** with the
**BD14** / **BD15** / **BD16** support definitions, all wired through
a new paragraph-driver variant.

- **`bidi::paired_bracket(c: char) -> Option<(char, BracketKind)>`**
  — the BD14 / BD15 lookup for the six ASCII brackets (`(` ↔ `)`,
  `[` ↔ `]`, `{` ↔ `}`). Returns `Some((paired_char, kind))` where
  `kind` is `BracketKind::Open` or `BracketKind::Close`. The wider
  Unicode `BidiBrackets.txt` table is not yet vendored under
  `docs/text/unicode-bidi/`; callers needing the ~60-entry UCS pair
  set can wrap `bracket_pairs` / `resolve_bracket_pairs` with their
  own `(char, BracketKind)` lookup of the same shape.
- **`bidi::bracket_pairs(chars: &[char], classes: &[BidiClass]) ->
  Vec<(usize, usize)>`** — the **BD16** stack walk over one
  isolating run sequence. Maintains the spec-mandated 63-element
  stack (overflow → empty list per the BD16 "stop processing
  BD16 ... and return an empty list" branch), pairs nested
  brackets by popping through the matching opener inclusively,
  honours the BD14 / BD15 "current bidi class is ON" gate (so
  brackets rewritten to `R` by X6 / RLO are ignored), and sorts
  the result by opener position in ascending logical order — the
  §3.3.5 N0 sequencing invariant.
- **`bidi::resolve_bracket_pairs(classes: &mut [BidiClass],
  pairs: &[(usize, usize)], embedding_level: u8, sos: BidiClass)`**
  — the **N0** rule applied to one isolating run sequence post-W7
  and pre-N1. For each pair, inspects the bracket interior for a
  strong type (EN / AN projected to R per the §3.3.5 note), then
  dispatches the N0 a / b / c.1 / c.2 / d cases in place:
  matching-embedding-inside → both brackets to embedding direction
  (N0 b); opposite-inside + preceding-strong-also-opposite → both
  brackets to that direction (N0 c.1); opposite-inside +
  preceding-strong-matches-embedding → both brackets to embedding
  direction (N0 c.2); no inside-strong → leave the pair untouched
  (N0 d). The trailing-NSM clarification ("any NSM following a
  paired bracket which changed under N0 should change to match the
  bracket") is honoured for the contiguous NSM run after each
  rewritten bracket. Pairs are processed sequentially in opener-
  ascending order so inner pairs see the rewrites of every outer
  pair already processed.
- **`bidi::process_paragraph_classes_with_brackets(classes, chars,
  base_level) -> ParagraphBidi`** + **`bidi::process_paragraph_with_brackets(
  text, base_level) -> (ParagraphBidi, Vec<usize>)`** — §3 paragraph
  driver mirrors of the round-227 / round-233 entry points, with
  N0 wired in between W7 and N1 per the §3.3.5 ordering. The two
  driver variants without `_with_brackets` stay the legacy pass-
  through (N0 not run), so existing callers see no behaviour
  change; the `_with_brackets` variants become the recommended
  default for any caller that handles arbitrary user-supplied
  text containing brackets.
- **`bidi_class('(' / ')' / '[' / ']' / '{' / '}') == BidiClass::ON`**
  — added the six ASCII brackets to the `bidi_class` lookup
  table. They were previously falling through to the L default
  per the unassigned-character convention, which would have made
  every bracket appear strong-L to the W / N walks. Existing test
  suites that assumed ASCII-bracket = L stay passing because the
  new ON class still resolves to the surrounding strong direction
  under N1 / N2 for LTR-only inputs (the only change is in
  bracket-spanning RTL / mixed-direction inputs — exactly what N0
  exists to fix).
- **23 unit tests + 22 integration tests**
  (`tests/round257_bidi_n0_bracket_pairs.rs`) cover every BD16
  worked-example line from the §3.1.3 spec table (`a(b)c → 2-4`,
  `a)b(c → None`, `a(b]c → None`, `a(b]c)d → 2-6`, `a(b)c)d → 2-4`,
  `a(b(c)d → 4-6`, `a(b(c)d) → 2-8, 4-6`, `a(b{c}d) → 2-8, 4-6`),
  every N0 case (b / c.1 / c.2 / d), the EN / AN projection note,
  the 63-stack overflow branch, the non-ON skip gate, the
  sequential-rewrite invariant, and the trailing-NSM clarification.

Out-of-scope tail (`README.md`): the full Unicode `BidiBrackets.txt`
table — ~60 paired-bracket entries across the Mathematical
Operators, Misc Mathematical Symbols, Supplementary Mathematical
Operators, CJK Symbols and Punctuation, and Ornamental Brackets
blocks — needs to land under `docs/text/unicode-bidi/` before
`paired_bracket` can grow past the ASCII set. The N0 algorithm
itself is complete; only the lookup table is partial. The L4
mirroring rule remains deferred for the same reason
(`BidiMirroring.txt` also not vendored).

### Added — UAX #9 §3.4 L3 combining-mark reordering (round 247)

Tenth UAX #9 surface on scribe and the third entry in the §3.4
line-level pass: rule **L3**, the post-L2 combining-mark reordering
that callers running a non-scribe mark-attachment policy need to
turn the L2 permutation into a visually-correct display stream.

- **`bidi::reorder_combining_marks(orig_classes: &[BidiClass],
  levels: &[u8], visual: &mut [usize])`** — in-place permutation
  adjuster. After [`reorder_line`], an RTL run that was originally
  `base, nsm_1, …, nsm_k` in logical order appears as
  `nsm_k, …, nsm_1, base` in visual order (L2 reversed the whole
  odd-level run). `reorder_combining_marks` walks the visual stream
  and reverses each such `[NSM, …, NSM, base]` block back to
  `[base, NSM, …, NSM]` per the §3.4 L3 wording "the ordering of
  the marks and the base character must be reversed". The block is
  identified by the strictly-decreasing logical-index signature
  L2 leaves behind, so the function is **idempotent** (re-running
  on already-rotated visual is a no-op) and multi-cluster RTL runs
  rotate each cluster independently without bleeding into one
  another.
- LTR (even-level) runs are untouched — L2 didn't reverse them so
  marks already follow the base. NSMs whose level differs from the
  following base (rare post-W1 leftover) and orphan NSMs with no
  matching base in the same level-1 block are conservatively left
  alone.
- Scribe's own GPOS mark-to-base + mark-to-mark stacker keeps marks
  in logical (post-base) order in both directions, so callers
  using scribe's renderer can skip the L3 step; the L3 entry point
  is for external callers wiring a different mark-attachment policy
  (the spec's "expects them to follow the base characters" branch).
- 9 unit + 15 integration tests cover the single-base RTL one-mark
  / two-mark / three-mark cases, multi-cluster RTL with same and
  different mark counts, AL (Arabic-letter) base, LTR marks
  untouched, RTL island in an LTR paragraph, LTR island in an RTL
  paragraph (level-2 nested, marks out of scope), empty input,
  orphan leading NSM, idempotency, the L3-yields-a-permutation
  invariant, end-to-end L1 → L2 → L3 composition, and the
  pure-RTL multi-letter word with one mark.
- **N0 (bracket-pair resolution per §3.1.3) and L4 (bidi-mirroring
  per §4.7) remain deferred** — N0 blocked on `BidiBrackets.txt`,
  L4 blocked on `BidiMirroring.txt`, neither yet vendored under
  `docs/text/unicode-bidi/` alongside the UAX HTML.

Provenance: rule L3 is transcribed verbatim from UAX #9 Revision 50
/ Unicode 16.0 §3.4 (`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html`).

### Added — UAX #9 §3.3.1 P1 multi-paragraph driver (round 233)

Ninth UAX #9 surface on scribe, sitting one step above the round 227
§3 whole-paragraph driver: the §3.3.1 **P1** rule "Split the text into
separate paragraphs. A paragraph separator (type B) is kept with the
previous paragraph. Within each paragraph, apply all the other rules
of this algorithm." composed with the per-paragraph driver to take a
whole-document `&str` and return one [`ParagraphBidi`] per paragraph
with whole-input byte / character bookkeeping attached.

- **`bidi::process_text(text: &str, base_level: Option<u8>) ->
  TextBidi`** — top-level entry point. Walks the input via the
  existing [`split_paragraphs`] (P1: trailing B kept with preceding
  paragraph), then dispatches each paragraph slice through
  [`process_paragraph_classes`] independently. Per-paragraph
  `char_byte_offsets` are rebased onto the whole input so callers
  index back into the original `&str` directly without adding a
  paragraph-local offset.
- **`bidi::TextBidi`** — multi-paragraph carrier. Fields:
  - `paragraphs: Vec<ParagraphSlice>` — one entry per paragraph
    found by P1, in logical order.
  - `total_chars: usize` — cumulative character count across all
    paragraphs (equals `text.chars().count()`).
- **`TextBidi::len` / `is_empty`** — paragraph-count accessors.
- **`TextBidi::locate_char(k: usize) -> Option<(usize, usize)>`** —
  given a whole-input logical character index, returns
  `(paragraph_index, paragraph_local_char_index)`. Linear walk over
  paragraphs; the docstring notes a future binary-search swap point
  if profiling demands it. Returns `None` past `total_chars`.
- **`bidi::ParagraphSlice`** — per-paragraph carrier. Fields:
  - `byte_range: Range<usize>` — half-open byte range of the
    paragraph (including its trailing B if any) in the original
    `&str`. Successive paragraph ranges tile the input
    contiguously.
  - `char_offset: usize` — cumulative character offset where this
    paragraph begins in the whole-text logical sequence.
  - `bidi: ParagraphBidi` — the §3 P → X → W → N → I output (round
    227 carrier, unchanged).
  - `char_byte_offsets: Vec<usize>` — whole-input byte index of
    each character in the paragraph.
- **`base_level: Option<u8>` HL1 semantics** — when `Some(_)`, every
  paragraph adopts the same base level (low-bit clamped). When
  `None`, P2 / P3 walk each paragraph independently, so e.g. the
  first paragraph of `"Hi\nשלום"` resolves LTR and the second RTL.
  Callers needing per-paragraph HL1 overrides loop
  [`process_paragraph`] manually.
- **Empty-input contract** — `process_text("")` returns
  `TextBidi { paragraphs: vec![], total_chars: 0 }`; the spec
  applies to no characters.
- **Tests** — 14 unit + 24 integration tests cover: P1 split on
  every class-B codepoint scribe's `bidi_class` recognises (LF, CR,
  NEL, FS, GS, RS, PS); trailing-B-kept-with-preceding-paragraph
  invariant; terminal LF not creating a phantom paragraph;
  consecutive separators producing one paragraph each; per-
  paragraph P2 / P3 independence (mixed Latin + Hebrew document);
  HL1 base-level override + low-bit clamp; whole-input byte-range
  contiguous tiling; `char_offset` accumulation across multi-byte
  inputs (Hebrew); `char_byte_offsets` whole-input indexing
  cross-checked against the original string; `total_chars` matches
  `chars().count()`; `locate_char` round-trip with offset
  arithmetic + out-of-bounds `None`; observational equivalence
  with a manual `split_paragraphs` + `process_paragraph` loop;
  per-paragraph `paragraph_level` cross-check; downstream
  `reorder_paragraph` continues to work via the carrier; manual
  L1 / L2 drive via `reset_trailing_levels` + `reorder_line`
  succeeds for every paragraph; `Clone + Eq + Debug` derive
  smoke tests on both carriers. Total scribe lib tests: 431 → 446.

**Still deferred (no change from round 227):**

- N0 bracket-pair resolution (blocked on `BidiBrackets.txt`).
- L4 bidi mirroring (blocked on `BidiMirroring.txt`).
- L3 combining-mark reordering (conditional on the renderer's
  mark-attachment policy; does not fire under scribe's current
  GPOS stacker).

Provenance: P1 transcribed verbatim from UAX #9 Revision 50 /
Unicode 16.0 §3.3.1 P1 at
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html`; the per-
paragraph dispatch composes the six per-rule entry points already
in this module, each citing the same dated snapshot directly.

### Added — UAX #9 §3 whole-paragraph driver (round 227)

Eighth UAX #9 surface on scribe, composing the six per-rule entry
points from rounds 186 / 191 / 198 / 204 / 217 / 220 into a single
high-level call. The driver runs §3.2 → §3.3.1 → §3.3.2 → §3.3.3 →
§3.3.4 → §3.3.5 → §3.3.6 on a `&str` or pre-classified `&[BidiClass]`
slice, then publishes the per-character resolved embedding level
ready for §3.4 L1 + L2 to consume per display line.

- **`bidi::process_paragraph(text: &str, base_level: Option<u8>) ->
  (ParagraphBidi, Vec<usize>)`** — text-driving entry point.
  Walks the input once for `char_indices()`, collecting one
  `BidiClass` per character plus a parallel byte-offset vector,
  then dispatches to the class-driven variant. The byte-offset
  vector locates each character in the original UTF-8 input —
  callers that need to slice back into `text` after the bidi
  pass (e.g. to extract per-run glyph clusters) read
  `text[char_byte_offsets[i]..]` to position the cursor at the
  character at logical index `i`.
- **`bidi::process_paragraph_classes(classes: &[BidiClass],
  base_level: Option<u8>) -> ParagraphBidi`** — class-driven
  entry point. Composes:
  - §3.3.1 paragraph level via the new internal
    `paragraph_level_from_classes` walker (mirrors the existing
    `paragraph_level` text walker — first-strong L / R / AL,
    skip LRI..PDI isolate spans per BD8, P3 default 0) unless
    the caller overrides with `base_level = Some(_)` (HL1).
  - §3.3.2 X1..X9 explicit-level pass via
    `resolve_explicit_levels`.
  - §3.3.3 X10 isolating-run-sequence partition via
    `isolating_run_sequences`.
  - §3.3.4 W1..W7 + §3.3.5 N1 + N2 + §3.3.6 I1 + I2
    **per-sequence** (per the X10 step 3 closing note that
    sequence order does not matter). Resolved levels are
    scattered back into the paragraph-wide level vector at the
    original logical offsets; X9-removed positions retain the
    X-rule level since W / N / I skipped them.
- **`bidi::ParagraphBidi`** — the carrier struct. Fields:
  - `paragraph_level: u8` — the §3.3.1 / HL1 result (0 or 1).
  - `classes: Vec<BidiClass>` — input verbatim (L1 needs the
    original types per the §3.4 normative note).
  - `effective_classes: Vec<BidiClass>` — X4 / X5 / X5a / X5b /
    X6 / X6a override-rewritten classes from X1..X9.
  - `removed: Vec<bool>` — X9-removed-flag set.
  - `levels: Vec<u8>` — per-character resolved embedding level
    after the full X → W → N → I sweep.
- **`ParagraphBidi::reorder_paragraph()`** — "whole paragraph as
  one line" convenience. Runs §3.4 L1 + L2 over the carrier and
  returns the logical-to-visual permutation.
- **`ParagraphBidi::reorder_line_range(line: Range<usize>)`** —
  per-line variant. Slices `classes` + `levels` to the given
  half-open range, runs L1 + L2 over the slice, and returns a
  permutation **relative to the line** (caller adds `line.start`
  to map back into the paragraph).
- **`base_level` low-bit clamp** — `base_level = Some(5)` maps to
  paragraph level 1 (the spec only defines two paragraph
  embedding levels). Removes a footgun for callers wiring HL1
  from external integer sources.
- **Tests** — 19 unit + 22 integration tests cover: P2 first-
  strong L / R / AL recognition, P3 no-strong default, BD8
  isolate-span skipping (matched + unmatched LRI), HL1
  base-level override (both directions + low-bit clamp), mixed
  L / R compositions (LTR with embedded RTL block at level 1,
  RTL paragraph lifting embedded LTR block to level 2,
  AL EN → R AN pipeline via W2 + W3 + I1), X9-removed positions
  retaining their X-rule level, text-driving char-byte offset
  advancement on ASCII / Hebrew / Arabic, the carrier's field-
  length invariant, input-class verbatim preservation, the
  `Clone + Eq + Debug` derive set on `ParagraphBidi`, the
  `reorder_paragraph` LTR-identity + RTL-reversal pair, per-line
  `reorder_line_range` on a split LTR paragraph, L1-reset of
  trailing whitespace agreeing with manual L1 + L2 chaining, and
  the §3.4 spec example "car means CAR." resolving to its
  published visual order. The class-driven P2 walker is cross-
  checked against the existing text-driving `paragraph_level` on
  six inputs spanning Latin / Hebrew / Arabic / mixed / LRI..PDI.
  Total scribe lib tests: 412 → 431.

**Still deferred (no change from round 220):**

- N0 bracket-pair resolution (blocked on `BidiBrackets.txt`).
- L4 bidi mirroring (blocked on `BidiMirroring.txt`).
- L3 combining-mark reordering (conditional on the renderer's
  mark-attachment policy; does not fire today under scribe's
  GPOS stacker).

Provenance: the driver composes the six existing per-rule entry
points already in this module; each cites
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` (UAX #9
Revision 50 / Unicode 16.0) directly in its own provenance line.
The §3 umbrella anchor lives at §3 "Basic Display Algorithm" of
the same dated snapshot.

### Added — UAX #9 §3.3.3 X10 isolating-run-sequence partition + sos/eos (round 220)

Seventh UAX #9 surface on scribe, sitting between the §3.3.2
explicit-level pass (X1..X9, round 217) and the §3.3.4 weak-type
pass (W1..W7, round 191): the §3.3.3 rule **X10** that walks
X1..X9's per-character embedding-level output, partitions the
paragraph into BD7 level runs, chains those runs across BD13
isolate-initiator → matching-PDI boundaries into isolating run
sequences, and derives per-sequence start-of-sequence (`sos`)
and end-of-sequence (`eos`) directional types from the higher of
the levels on either side of each sequence boundary.

- **`bidi::level_runs(levels: &[u8]) -> Vec<LevelRun>`** — BD7
  partition. Returns a contiguous list of half-open
  `LevelRun { start, end, level }` ranges fully covering
  `0..levels.len()`. X9-removed positions are included in their
  containing level run; W / N / I phases consume them via
  `IsolatingRunSequence::indices` which performs the X9 skip.
- **`bidi::isolating_run_sequences(classes: &[BidiClass],
  explicit: &ExplicitLevels, paragraph_level: u8) ->
  Vec<IsolatingRunSequence>`** — BD13 chaining + X10 step 2
  sos / eos derivation. For every level run whose last non-X9-
  removed character is an isolate initiator (LRI / RLI / FSI), if
  BD9's matching-PDI scan finds a PDI **and** that PDI is the
  first character of its own level run, the next run is appended
  to the current sequence; otherwise the chain closes. The sos /
  eos pair on each sequence reflects the X10 step 2 prose: scan
  outward past X9-removed characters; if no non-removed character
  exists on either side, OR the eos side is an unmatched isolate
  initiator, fall back to the paragraph embedding level. "If the
  higher level is odd, the sos or eos is R; otherwise, it is L."
- **`bidi::IsolatingRunSequence::indices(&removed)`** — iterator
  over the constituent character indices in logical order while
  skipping X9-removed positions. Drives the in-place W / N / I
  passes per sequence. Per the X10 step 3 closing note "the order
  that one isolating run sequence is treated relative to another
  does not matter."
- **New public types** — `LevelRun { start, end, level }` and
  `IsolatingRunSequence { runs, level, sos, eos }`. Both
  `Clone + PartialEq + Eq + Debug` for downstream snapshot /
  memoisation use cases.
- **Tests** — 17 unit + 16 integration tests cover the BD7
  partition (empty / uniform / multi-change / coverage invariant),
  the X10 sos / eos derivation under paragraph-edge / RLE-bounded
  / unmatched-isolate / RTL-base-paragraph conditions, the BD13
  chaining across LRI..PDI verifying that the matching PDI is the
  first character of its run, the BD9 matching-PDI scan with
  nested isolates and ignored embedding-formatting characters, the
  BD13 invariants (every level run belongs to exactly one
  sequence; all runs in a sequence share their embedding level),
  the `indices` iterator's X9-skip + isolate-format-character
  preservation, and an end-to-end X → W → N → I pipeline composed
  per-sequence. Total scribe lib tests: 395 → 412.

**Out of scope (still deferred):**

- **N0 bracket-pair resolution** (§3.1.3 / §3.3.5) — blocked on
  `BidiBrackets.txt` from the Unicode Character Database; not yet
  vendored under `docs/text/unicode-bidi/`.
- **L4 bidi mirroring** (§3.4 / §4.7) — blocked on
  `BidiMirroring.txt` from the same UCD release; not yet vendored.
- **L3 combining-mark reordering** (§3.4) — conditional on the
  rendering engine's mark-attachment policy per the §3.4 guard;
  does not fire today because scribe's GPOS mark-to-base /
  mark-to-mark stacker keeps logical (post-base) order in both
  directions.

Provenance: transcribed verbatim from UAX #9 Revision 50 /
Unicode 16.0 §3.1.2 (BD7, BD9, BD13) + §3.3.3 (X10) at
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html`.

### Added — UAX #9 §3.3.2 explicit-level / override / isolate stack pass (X1..X9, round 217)

Sixth UAX #9 surface on scribe, slotting in front of the existing
W / N / I / L pipeline: the §3.3.2 explicit-level rules **X1..X9**
that walk a paragraph's bidi class slice while maintaining the
spec's *directional status stack* + the three overflow / valid
counters, and emit a per-character embedding level vector ready
for the X10 isolating-run-sequence partition.

- **`bidi::resolve_explicit_levels(classes: &[BidiClass],
  paragraph_level: u8) -> ExplicitLevels`** — single-pass walk
  over the paragraph implementing X1 (stack init), X2..X5
  (RLE / LRE / RLO / LRO embedding / override pushes), X5a / X5b
  (RLI / LRI isolate pushes), X5c (FSI resolved via P2 / P3 over
  the FSI..matching-PDI span and treated as RLI or LRI
  accordingly), X6 (regular-character level assignment + override
  rewrite), X6a (PDI: unwind embeddings down to + including the
  matched isolate frame), X7 (PDF: pop the matching embedding,
  with overflow-counter bookkeeping for unmatched / overflow
  cases), X8 (B characters always at the paragraph level), and X9
  (mark RLE / LRE / RLO / LRO / PDF / BN as removed; isolate-
  formatting characters LRI / RLI / FSI / PDI are *not* removed
  per the X9 note).
- **`bidi::ExplicitLevels`** — the return struct, carrying three
  parallel vectors of length `classes.len()`:
  - `levels: Vec<u8>` — per-character embedding level. Index
    preservation lets the downstream X10 partition + W / N / I
    phases map back to the original logical offsets.
  - `effective_classes: Vec<BidiClass>` — input classes with X4 /
    X5 / X5a / X5b / X6 / X6a override rewrites applied. Under
    an `L` override every non-formatting character is rewritten
    to `L`; under an `R` override to `R`; under neutral (the
    starting state, embeddings and isolates) classes are
    unchanged.
  - `removed: Vec<bool>` — `true` for the six X9-removed types.
- **`bidi::MAX_DEPTH`** — `pub const MAX_DEPTH: u8 = 125;` per
  UAX #9 §3.1.2 BD2 ("this specification now guarantees that the
  value of 125 for max_depth will not be increased (or
  decreased) in future versions"). Embedding initiators that
  would push past this depth become *overflow* events tracked
  through the overflow_embedding / overflow_isolate counters.
- **`oxideav_scribe::resolve_explicit_levels`** +
  **`oxideav_scribe::ExplicitLevels`** + **`oxideav_scribe::MAX_DEPTH`**
  — public re-exports alongside the existing W / N / I / L
  surface.

The X10 isolating-run-sequence partition (BD13) is *not* part of
this round — it runs on top of X1..X9's level output and feeds
the W / N / I passes per sequence. The bracket-pair rule N0 (still
blocked on `BidiBrackets.txt`) and the L3 / L4 mirroring rules
remain deferred.

42 new tests (19 unit + 23 integration via
`tests/round217_bidi_explicit_levels.rs`):

- **X1 init** — empty-paragraph no-op, plain Latin / Arabic
  paragraph-level dispatch, paragraph-level=1 path.
- **X2..X5** — RLE / LRE / RLO / LRO each pushing the spec's
  least-greater-odd / -even level above the stack top, the
  embedding-initiator's reported level reflecting the new scope,
  the override status correctly rewriting inner classes.
- **X5a / X5b** — RLI / LRI pushing the same least-greater-
  odd / -even levels but as isolate frames, the initiator's own
  level reflecting the *enclosing* scope per the spec text, the
  X9 non-removal of the four isolate-formatting characters.
- **X5c** — FSI resolved via the in-span P2 + P3 mini-pass:
  strong-L-inside → LRI, strong-AL-inside → RLI, no-strong →
  default LRI, P2's inner isolate-skip working through nested
  LRI..PDI inside the FSI span.
- **X6** — override rewriting only non-formatting types.
- **X6a** — PDI matching the enclosing isolate frame: unwind
  embeddings above it, pop the isolate, unmatched PDI ignored.
- **X7** — PDF popping the matching embedding, PDF at top level
  ignored, PDF inside an overflow scope absorbed by the overflow
  counter.
- **X8** — B inside any embedding still reported at the paragraph
  level.
- **X9** — RLE / LRE / RLO / LRO / BN / PDF marked removed; LRI /
  RLI / FSI / PDI not removed.
- **Overflow** — 64-RLE-deep chain pinning the inner level at
  MAX_DEPTH = 125; doubly-nested RLI..PDI..PDI pair both popping
  cleanly within bounds.
- **Public surface** — re-export shape sanity check, MAX_DEPTH
  constant value, plus mixed Latin / Hebrew paragraph fed through
  `paragraph_level → resolve_explicit_levels` end-to-end.

Provenance: rules transcribed verbatim from
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` §3.3.2 (UAX
#9 Revision 50, Unicode 16.0). BD2's `max_depth = 125` constant
also pinned to the same file.

### Added — UAX #9 §3.4 line-level reordering rules L1 + L2 (round 210)

Fifth UAX #9 surface on scribe, layered on top of the round 204
implicit-level pass: the §3.4 line-level reordering rules L1 and
L2. The pair closes the per-character pipeline (P → W → N → I →
L1) and emits the logical-to-visual permutation a renderer walks
to lay glyphs out in display order.

- **`bidi::reset_trailing_levels(orig_classes: &[BidiClass],
  levels: &mut [u8], paragraph_level: u8)`** — in-place pass over
  one line implementing UAX #9 §3.4 rule **L1**. Resets the
  embedding level of:
  - every segment separator (class `S`) per case (1),
  - every paragraph separator (class `B`) per case (2),
  - every maximal run of whitespace (`WS`) and/or isolate-
    formatting characters (`LRI` / `RLI` / `FSI` / `PDI`)
    immediately preceding such a separator per case (3),
  - the same trailing-filler run at the end of the line per
    case (4),
  back to `paragraph_level`. Per UAX #9 §3.4 the lookup uses the
  **original** bidi classes ("The types of characters used here
  are the *original* types, not those modified by the previous
  phase."), so the caller passes the input class slice alongside
  the post-I-rules level vector. Panics on length mismatch.
- **`bidi::reorder_line(levels: &[u8]) -> Vec<usize>`** —
  permutation pass implementing UAX #9 §3.4 rule **L2**. Walks
  from the maximum level in `levels` down to the lowest odd
  level, and for each iteration level reverses every maximal
  contiguous run of positions whose level is `>= iteration_level`.
  Returns a `Vec<usize>` of length `levels.len()` mapping visual
  position to logical index (i.e. `visual[v] == logical_index`),
  the form a renderer / line builder consumes when emitting
  glyphs in display order. Returns the identity for empty input
  or input with no odd levels.
- **`oxideav_scribe::reset_trailing_levels`** +
  **`oxideav_scribe::reorder_line`** — public re-exports alongside
  the existing W / N / I pass entry points.

The pair completes the per-character UAX #9 algorithm scribe
needs to drive mixed-direction layout: a caller feeds a line
through `bidi_class` → `resolve_weak_types` →
`resolve_neutral_types` → `resolve_implicit_levels` →
`reset_trailing_levels` → `reorder_line` and ends with the
visual-order index sequence the line renderer walks. The X-rules
(explicit-embedding / override / isolate stack machinery + the
isolating-run-sequence partition), the N0 bracket-pair rule, and
the L3 / L4 mirroring rules remain deferred.

**38 new tests** (17 unit + 21 integration via
`tests/round210_bidi_line_reordering.rs`): every L1 sub-case (S /
B separators in cases 1 + 2; WS-before-separator and
isolate-formatting-before-separator in case 3; trailing-WS at end
of line in case 4); the §3.4 normative "original classes"
clause; interior whitespace and leading whitespace negative
controls; length-mismatch panic; empty input; multiple
separators on one line; identity and full-reverse for L2; UAX #9
§3.4 worked examples 1, 2, 3, and 4 reproduced by their
resolved-level vectors (the spec's "Resolved levels" row) and
verified against the spec's "Display" row; permutation-invariant
sweep over a small set of mixed-level shapes; and end-to-end
`W → N → I → L1 → L2` pipelines on real Arabic text, including
the §3.4 Example-1 line "car means CAR." reconstructed from real
characters with the paragraph level detected by `paragraph_level`.

Provenance: rules transcribed verbatim from
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` §3.4 (UAX #9
Revision 50, Unicode 16.0).

### Added — UAX #9 §3.3.6 implicit-level resolution rules I1 + I2 (round 204)

Fourth UAX #9 surface on scribe, layered on top of the round 198
neutral-type pass: the §3.3.6 implicit-level resolution rules I1
and I2. The phase computes the per-character resolved embedding
level the L-rule reordering pass consumes; it is the final
character-level transformation in the algorithm before line-level
work begins.

- **`bidi::resolve_implicit_levels(classes: &[BidiClass],
  embedding_level: u8) -> Vec<u8>`** — pass over one isolating run
  sequence (the same slice already mutated through
  `resolve_weak_types` + `resolve_neutral_types`) returning a
  per-character level vector. The implementation is UAX #9 §3.3.6
  Table 5 verbatim:
  - **I1** (even embedding levels): `R` → EL+1, `EN` / `AN` → EL+2.
  - **I2** (odd embedding levels): `L` / `EN` / `AN` → EL+1.
  - `BN` is ignored per §5.2 ("In rules I1 and I2, ignore BN.") —
    its level stays at `embedding_level`. A surviving `NSM` (the
    rare case where W1 left it intact) is treated the same; the
    L-rule pass folds both.
- **`oxideav_scribe::resolve_implicit_levels`** +
  `oxideav_scribe::bidi::resolve_implicit_levels` — public
  re-exports alongside the W / N pass entry points.

After the call the caller has the level vector the §3.4 / §3.4.1
L-rule reordering pass needs. The X-rules (paragraph + embedding /
isolate stack machinery + the isolating-run-sequence partition)
remain deferred; callers that already know their embedding level
pass it directly, which matches the same contract `paragraph_level`
returned in round 186 for the outer level.

**23 new tests** (8 unit + 15 integration via
`tests/round204_bidi_implicit_levels.rs`): every Table 5 row at
multiple embedding levels (even / odd, base levels 0 / 1 / 2 / 3
plus EL = 124 for the max-depth overflow note), the `BN`
carve-out at both even and odd embedding levels, empty-input
no-op, output-length-equals-input-length defensive sweep, and
full W → N → I pipelines on LTR / RTL paragraph fragments —
including the §3.3.5 closing prose example "IT IS A bmw 500, OK."
reduced to its embedded `R EN ET EN R` run at EL 1, which
exercises W5's ET-EN collapse + I1's EN-up-two in a single
end-to-end level vector.

Cleanup: removed two stale provenance lines in `src/variations.rs`
and `src/shaping/arabic_pf.rs`; the substantive provenance
citation (Microsoft OpenType chapters for variations,
`UnicodeData.txt` decomposition mappings for Arabic presentation
forms) is unchanged.

Provenance: rules transcribed verbatim from
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` §3.3.6 (UAX #9
Revision 50, Unicode 16.0).

### Added — UAX #9 §3.3.5 neutral-type resolution rules N1 + N2 (round 198)

Third concrete UAX #9 surface on scribe, layered on top of the
round 191 weak-type pass: the §3.3.5 neutral / isolate-formatting
resolution rules N1 and N2. The phase finishes resolving every
former neutral or isolate-formatting position to a strong
direction, completing the input vocabulary the §3.3.6 implicit-
level pass (I1 / I2) will consume in a follow-up round.

- **`bidi::resolve_neutral_types(classes: &mut [BidiClass],
  embedding_level: u8, sos: BidiClass, eos: BidiClass)`** — in-place
  pass over one isolating run sequence (the same slice already
  mutated by `resolve_weak_types`) applying:
  - **N1** — every maximal contiguous run of NI elements (`B` /
    `S` / `WS` / `ON` / `LRI` / `RLI` / `FSI` / `PDI`) collapses to
    the strong type on either side when both sides agree, with `EN`
    and `AN` counting as `R` per the spec's "European and Arabic
    numbers act as if they were R". `NSM` / `BN` are skipped by the
    strong-side walk (they are non-strong but also non-NI). `sos` /
    `eos` provide the strong type at sequence boundaries.
  - **N2** — every NI run whose strong neighbours disagree
    collapses to the embedding direction (`L` for even
    `embedding_level`, `R` for odd).
- **`oxideav_scribe::resolve_neutral_types`** + the matching
  `oxideav_scribe::bidi::resolve_neutral_types` — public re-exports
  alongside `resolve_weak_types`.

After the pass the slice contains no NI; `NSM` and `BN` survive
untouched (they are not in the NI alias and the §3.3.6 implicit-
level rules handle them).

**N0 (bracket-pair resolution per §3.1.3 + §3.3.5) is deferred** —
it requires the Unicode `BidiBrackets.txt` data file to identify
opening / closing paired brackets, which is not yet vendored under
`docs/`. The N1 / N2 surface is forward-compatible: an N0
implementation lands as a pre-N1 pass that turns bracket positions
into strong types, after which N1 / N2 continues to apply
unchanged.

**21 new tests** (10 unit + 11 integration via
`tests/round198_bidi_neutral_types.rs`): every spec example —
`L NI L → L L L`, `R NI R → R R R`, the full R / AN / EN N1 table
with EN / AN counting as R, the N2 mismatch table at both
embedding levels, the full NI alias collapsing in one run,
`NSM` / `BN` pass-through across NI boundaries, `sos` / `eos`
driving boundary-spanning runs, idempotence on NI-free slices,
and the compose-with-W realistic Arabic + numbers pipeline.

Provenance: rules transcribed verbatim from
`docs/text/unicode-bidi/tr9-50-uax9-unicode16.html` §3.3.5 (UAX #9
Revision 50, Unicode 16.0). No external library source was
consulted at any point.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).